### PR TITLE
Add support for tree-like outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "icon": "images/icon.png",
     "main": "./out/src/extension",
     "engines": {
-        "vscode": "^1.21.0"
+        "vscode": "^1.25.0"
     },
     "categories": [
         "Programming Languages"

--- a/src/AsciiDocSymbolProvider.ts
+++ b/src/AsciiDocSymbolProvider.ts
@@ -10,7 +10,7 @@ import {
 export default function registerDocumentSymbolProvider(): Disposable {
 
         const _atxPattern = /^((=|#){1,6})\s+(.+)$/;
-        const _blockPattern = /^[.\-]{4}$/;
+        const _blockPattern = /^(\.{4}|-{4})$/;
 
         return languages.registerDocumentSymbolProvider('asciidoc', {
 

--- a/src/AsciiDocSymbolProvider.ts
+++ b/src/AsciiDocSymbolProvider.ts
@@ -1,35 +1,77 @@
 import {
     languages,
-    Disposable,
     CancellationToken,
-    Location,
-    Position,
-    TextDocument,
-    SymbolInformation,
-    SymbolKind
+    Disposable,
+    DocumentSymbol,
+    SymbolKind,
+    TextDocument
 } from 'vscode';
 
 export default function registerDocumentSymbolProvider(): Disposable {
-    
-        const _atxPattern = /^(=|#){1,6}\s+.+/;
+
+        const _atxPattern = /^((=|#){1,6})\s+(.+)$/;
+        const _blockPattern = /^[.\-]{4}$/;
 
         return languages.registerDocumentSymbolProvider('asciidoc', {
-    
-            provideDocumentSymbols(document: TextDocument, token: CancellationToken): SymbolInformation[] {
-    
-                const result: SymbolInformation[] = [];
+
+            provideDocumentSymbols(document: TextDocument, token: CancellationToken): DocumentSymbol[] {
+
+                const symbols: DocumentSymbol[] = [];
                 const lineCount = Math.min(document.lineCount, 10000);
+
+                // Really basic way of ignoring literal blocks when parsing headers.
+                let currentBlock: string = null;
+
                 for (let line = 0; line < lineCount; line++) {
-                    const {text} = document.lineAt(line);
-    
-                    if (_atxPattern.test(text)) {
-                        // atx-style, 1-6 = characters
-                        result.push(new SymbolInformation(text, SymbolKind.File, '',
-                            new Location(document.uri, new Position(line, 0))));
+                    const {text, range} = document.lineAt(line);
+
+                    if (_blockPattern.test(text)) {
+                        // Entering a block.
+                        if (currentBlock === null) {
+                            currentBlock = text;
+                        }
+
+                        // Exiting a block.
+                        else if (text === currentBlock) {
+                            currentBlock = null;
+                        }
+
+                        continue;
+                    }
+
+                    // Ignore lines in a literal block.
+                    if (currentBlock !== null) {
+                        continue;
+                    }
+
+                    const match = _atxPattern.exec(text);
+                    if (match !== null) {
+                        const depth = match[1].length;
+                        const symbol = new DocumentSymbol(
+                            match[3],
+                            null,
+                            SymbolKind.String,
+                            range,
+                            range
+                        );
+
+                        let parent = symbols;
+
+                        for (let current = 1; current < depth; current++) {
+                            // Some documents are not well-formed; promote this heading to a higher level if that is the
+                            // case.
+                            if (parent.length === 0) {
+                                break;
+                            }
+
+                            parent = parent[parent.length - 1].children;
+                        }
+
+                        parent.push(symbol);
                     }
                 }
-    
-                return result;
+
+                return symbols;
             }
         });
     }


### PR DESCRIPTION
Use the new `DocumentSymbol` API to provide a hierarchical symbol tree in order to have a more useful outline for navigation. This is a huge improvement for working with large AsciiDoc documents.

The parsing routine added here is pretty rudimentary, but it seems to get the job done in my testing and looks quite nice.

This also fixes a small issue where lines that _look_ like headers inside literal blocks showed up in the outline.

Resolves issue #95 and #87.