### PR TITLE
fixes typos in Description for AsciiDoc.forceUnixStyleSeparator

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
                 "AsciiDoc.forceUnixStyleSeparator": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Force set the file separator styel to unix style. If set false, separator styel will follow the system style."
+                    "description": "Force set the file separator style to unix style. If set false, separator style will follow the system style."
                 },
                 "AsciiDoc.prefix": {
                     "type": "string",


### PR DESCRIPTION
fixed minor typos in the description field for AsciiDoc.forceUnixStyleSeparator