### PR TITLE
Typographic quotes, build script overhaul, email pattern fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,12 +339,12 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Use asciidoctor js instead of the 'asciidoctor_command'"
-                },
-                "asciidoc.forceUnixStyleSeparator": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Force set the file separator style to unix style. If set false, separator style will follow the system style."
-                }
+				},
+				"asciidoc.forceUnixStyleSeparator": {
+					"type": "boolean",
+					"default": true,
+					"description": "Force set the file separator style to unix style. If set false, separator style will follow the system style."
+				}
 			}
 		},
 		"configurationDefaults": {
@@ -391,8 +391,8 @@
 		"ts-loader": "^4.0.1"
 	},
 	"dependencies": {
-        "asciidoctor.js": "1.5.6",
-        "asciidoctor-plantuml": "^0.10.0",
+		"asciidoctor.js": "1.5.6",
+		"asciidoctor-plantuml": "^0.10.0",
 		"copy-paste": "^1.2.0",
 		"file-url": "^1.0.1",
 		"follow-redirects": "^1.4.1",

--- a/script/build
+++ b/script/build
@@ -6,21 +6,21 @@ exitdialog() {
   exit ${1:-1}
 }
 
+# Generate plist syntax
 generate_syntax() {
-  # Generate plist syntax
   echo "==> Converting YAML syntax to plist"
   [[ ! -x script/yaml-to-plist ]] && chmod +x script/yaml-to-plist
   script/yaml-to-plist "syntaxes/Asciidoctor.YAML-tmLanguage" "syntaxes/Asciidoctor.tmLanguage" || exitdialog $?
 }
 
+# Install node dependencies
 npm_local_deps() {
-  # Install node dependencies
   echo "==> Installing local dependencies"
   npm install || exitdialog $?
 }
 
+# Check status of vsce and typescript dependencies
 npm_global_deps() {
-  # Check status of vsce and typescript dependencies
   unset deps
   npm list -g vsce &>/dev/null || deps+=("vsce")
   npm list -g typescript &>/dev/null || deps+=("typescript")
@@ -30,15 +30,15 @@ npm_global_deps() {
   fi
 }
 
+# Package extension
 package() {
-  # Package extension
   echo "==> Packaging extension"
   rm -f *.vsix
   vsce package || exitdialog
 }
 
+# Install extension
 install() {
-  # Install extension
   echo "==> Installing extension"
   code --install-extension *.vsix || exitdialog $?
 }

--- a/script/build
+++ b/script/build
@@ -88,11 +88,9 @@ cd "$(dirname "$0")/.."
 # Run help() if -h or --help or help have been used as argument
 [[ -z $@ || $1 =~ (-h|--help|help) ]] && help && exit
 
-args=()
-for arg in $@ ; do args+=("$arg") ; done
-
-for arg in ${args[@]} ; do
-  case $arg in
+# Run operations for each argument
+while [[ $# > 0 ]] ; do
+  case $1 in
     build)
       npm_local_deps || exitdialog $?
       npm_global_deps || exitdialog $?
@@ -124,4 +122,5 @@ for arg in ${args[@]} ; do
       echo -e "==> ${red}${bold}ERROR${reset}: unknown argument '$1'"
       ;;
   esac
+  shift
 done

--- a/script/build
+++ b/script/build
@@ -1,8 +1,46 @@
 #!/bin/bash
 
+red="\033[0;31m"
+bold="\033[1m"
+reset="\033[0m"
+
+
+# Help text
+help() {
+  echo -e "AsciiDoc extension build script
+
+  ${bold}-h${reset}, ${bold}--help${reset}, ${bold}help$reset
+    show this help
+
+  ${bold}build${reset}
+    1. install local node dependencies
+    2. install global node dependencies
+    3. generate the .tmLanguage file
+    4. package the extension
+
+  ${bold}npm${reset}
+    1. install local node dependencies
+    2. install global node dependencies
+
+  ${bold}npm_local${reset}, ${bold}npm_local_deps${reset}
+    1. install local node dependencies
+
+  ${bold}npm_global${reset}, ${bold}npm_global_deps${reset}
+    1. install global node dependencie
+
+  ${bold}generate${reset}, ${bold}generate_syntax${reset}
+    1. generate the .tmLanguage file
+
+  ${bold}package${reset}
+    1. package the extension
+
+  ${bold}install${reset}
+    1. install the extension\n"
+}
+
 # Exit if any operation fails
 exitdialog() {
-  echo -e "==> \033[0;31m\033[1mERROR\033[0m: build aborted"
+  echo -e "==> $red$boldERROR$reset: build aborted"
   exit ${1:-1}
 }
 
@@ -43,12 +81,15 @@ install() {
   code --install-extension *.vsix || exitdialog $?
 }
 
+
 # Move to project root
 cd "$(dirname "$0")/.."
 
+# Run help() if -h or --help or help have been used as argument
+[[ -z $@ || $1 =~ (-h|--help|help) ]] && help && exit
+
 args=()
 for arg in $@ ; do args+=("$arg") ; done
-[[ -z $args ]] && args=(build)
 
 for arg in ${args[@]} ; do
   case $arg in
@@ -80,7 +121,7 @@ for arg in ${args[@]} ; do
       ;;
 
     *)
-      echo -e "==> \033[0;31m\033[1mERROR\033[0m: unknown argument '${arg}'"
+      echo -e "==> $red$boldERROR$reset: unknown argument '${arg}'"
       ;;
   esac
 done

--- a/script/build
+++ b/script/build
@@ -53,30 +53,30 @@ for arg in $@ ; do args+=("$arg") ; done
 for arg in ${args[@]} ; do
   case $arg in
     build)
-      npm_local_deps
-      npm_global_deps
-      generate_syntax
-      package
+      npm_local_deps || exitdialog $?
+      npm_global_deps || exitdialog $?
+      generate_syntax || exitdialog $?
+      package || exitdialog $?
       ;;
 
     npm|npm_local|npm_local_deps)
-      npm_local_deps
+      npm_local_deps || exitdialog $?
       ;;
 
     npm|npm_global|npm_global_deps)
-      npm_global_deps
+      npm_global_deps || exitdialog $?
       ;;
 
     generate|generate_syntax)
-      generate_syntax
+      generate_syntax || exitdialog $?
       ;;
 
     package)
-      package
+      package || exitdialog $?
       ;;
 
     install)
-      install
+      install || exitdialog $?
       ;;
 
     *)

--- a/script/build
+++ b/script/build
@@ -40,7 +40,7 @@ help() {
 
 # Exit if any operation fails
 exitdialog() {
-  echo -e "==> $red$boldERROR$reset: build aborted"
+  echo -e "==> ${red}${bold}ERROR${reset}: build aborted"
   exit ${1:-1}
 }
 
@@ -121,7 +121,7 @@ for arg in ${args[@]} ; do
       ;;
 
     *)
-      echo -e "==> $red$boldERROR$reset: unknown argument '${arg}'"
+      echo -e "==> ${red}${bold}ERROR${reset}: unknown argument '$1'"
       ;;
   esac
 done

--- a/script/build
+++ b/script/build
@@ -6,33 +6,81 @@ exitdialog() {
   exit ${1:-1}
 }
 
+generate_syntax() {
+  # Generate plist syntax
+  echo "==> Converting YAML syntax to plist"
+  [[ ! -x script/yaml-to-plist ]] && chmod +x script/yaml-to-plist
+  script/yaml-to-plist "syntaxes/Asciidoctor.YAML-tmLanguage" "syntaxes/Asciidoctor.tmLanguage" || exitdialog $?
+}
+
+npm_local_deps() {
+  # Install node dependencies
+  echo "==> Installing local dependencies"
+  npm install || exitdialog $?
+}
+
+npm_global_deps() {
+  # Check status of vsce and typescript dependencies
+  unset deps
+  npm list -g vsce &>/dev/null || deps+=("vsce")
+  npm list -g typescript &>/dev/null || deps+=("typescript")
+  if [[ -n $deps ]] ; then
+    echo "==> Installing global dependencies [needs sudo]"
+    sudo npm install -g ${deps[@]} || exitdialog $?
+  fi
+}
+
+package() {
+  # Package extension
+  echo "==> Packaging extension"
+  rm -f *.vsix
+  vsce package || exitdialog
+}
+
+install() {
+  # Install extension
+  echo "==> Installing extension"
+  code --install-extension *.vsix || exitdialog $?
+}
+
 # Move to project root
 cd "$(dirname "$0")/.."
 
-# Generate plist syntax
-echo "==> Converting YAML syntax to plist"
-[[ ! -x script/yaml-to-plist ]] && chmod +x script/yaml-to-plist
-script/yaml-to-plist "syntaxes/Asciidoctor.YAML-tmLanguage" "syntaxes/Asciidoctor.tmLanguage" || exitdialog $?
+args=()
+for arg in $@ ; do args+=("$arg") ; done
+[[ -z $args ]] && args=(build)
 
-# Build extension
-echo "==> Installing local dependencies"
-npm install || exitdialog $?
+for arg in ${args[@]} ; do
+  case $arg in
+    build)
+      npm_local_deps
+      npm_global_deps
+      generate_syntax
+      package
+      ;;
 
-# Check status of vsce and typescript dependencies
-unset deps
-npm list -g vsce &>/dev/null || deps+=("vsce")
-npm list -g typescript &>/dev/null || deps+=("typescript")
-if [[ -n $deps ]] ; then
-  echo "==> Installing global dependencies [needs sudo]"
-  sudo npm install -g ${deps[@]} || exitdialog $?
-fi
+    npm|npm_local|npm_local_deps)
+      npm_local_deps
+      ;;
 
-# Package extension
-echo "==> Packaging extension"
-rm -f *.vsix
-vsce package || exitdialog
+    npm|npm_global|npm_global_deps)
+      npm_global_deps
+      ;;
 
-if [[ $1 == install ]] ; then
-  echo "==> Installing extension"
-  code --install-extension *.vsix || exitdialog $?
-fi
+    generate|generate_syntax)
+      generate_syntax
+      ;;
+
+    package)
+      package
+      ;;
+
+    install)
+      install
+      ;;
+
+    *)
+      echo -e "==> \033[0;31m\033[1mERROR\033[0m: unknown argument '${arg}'"
+      ;;
+  esac
+done

--- a/syntaxes/Asciidoctor.YAML-tmLanguage
+++ b/syntaxes/Asciidoctor.YAML-tmLanguage
@@ -540,6 +540,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   emphasis_double:
     comment: |
@@ -574,6 +575,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   monospaced_double:
     comment: |
@@ -608,6 +610,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   mark_double:
     comment: |
@@ -642,6 +645,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   passthrough:
     comment: |
@@ -696,6 +700,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   emphasis:
     comment: |
@@ -732,6 +737,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   monospaced:
     comment: |
@@ -768,6 +774,7 @@ repository:
     - include: '#superscript'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   mark:
     comment: |
@@ -838,6 +845,7 @@ repository:
     - include: '#mark'
     - include: '#superscript'
     - include: '#characters'
+    - include: '#mail'
 
   superscript:
     comment: |
@@ -872,6 +880,7 @@ repository:
     - include: '#mark'
     - include: '#subscript'
     - include: '#characters'
+    - include: '#mail'
 
   mail:
     comment: |

--- a/syntaxes/Asciidoctor.YAML-tmLanguage
+++ b/syntaxes/Asciidoctor.YAML-tmLanguage
@@ -835,6 +835,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.string.subscript.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#emphasis_double'
     - include: '#monospaced_double'
@@ -870,6 +872,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.string.superscript.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#emphasis_double'
     - include: '#monospaced_double'

--- a/syntaxes/Asciidoctor.YAML-tmLanguage
+++ b/syntaxes/Asciidoctor.YAML-tmLanguage
@@ -418,6 +418,82 @@ repository:
 
   inline:
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
+    - include: '#passthrough'
+    - include: '#strong_double'
+    - include: '#emphasis_double'
+    - include: '#monospaced_double'
+    - include: '#mark_double'
+    - include: '#strong'
+    - include: '#emphasis'
+    - include: '#monospaced'
+    - include: '#mark'
+    - include: '#superscript'
+    - include: '#subscript'
+    - include: '#mail'
+
+  typographic_quotes_single:
+    comment: |
+      Typographic quotes single.
+
+      Examples:
+        '`Text`'
+    name: markup.italic.quote.typographic-quotes.single.asciidoc
+    contentName: markup.italicinner.quote.typographic-quotes.single.asciidoc
+    begin: |-
+      (?x)
+      (\[[^\]]*?\])?         # might be preceded by an attributes list
+      (?<=^|\W)(?<!\\|})     # must be preceded by nonword character, and not by escape or } (attribute)
+      ('`)(?=\S[\S ]*\S`'\W) # must be followed by inline characters and closed
+    beginCaptures:
+      '1': {name: support.variable.attributelist.asciidoc}
+      '2': {name: punctuation.definition.typographic-quotes.single.begin.asciidoc}
+    end: |-
+      (?x)
+      (`')
+      (?!\w) # must be followed by a nonword character
+    endCaptures:
+      '1': {name: punctuation.definition.typographic-quotes.single.begin.asciidoc}
+    patterns:
+    - include: '#typographic_quotes_double'
+    - include: '#passthrough'
+    - include: '#strong_double'
+    - include: '#emphasis_double'
+    - include: '#monospaced_double'
+    - include: '#mark_double'
+    - include: '#strong'
+    - include: '#emphasis'
+    - include: '#monospaced'
+    - include: '#mark'
+    - include: '#superscript'
+    - include: '#subscript'
+    - include: '#mail'
+
+  typographic_quotes_double:
+    comment: |
+      Typographic quotes double.
+
+      Examples:
+        "`Text`"
+    name: markup.italic.quote.typographic-quotes.double.asciidoc
+    contentName: markup.italicinner.quote.typographic-quotes.double.asciidoc
+    begin: |-
+      (?x)
+      (\[[^\]]*?\])?         # might be preceded by an attributes list
+      (?<=^|\W)(?<!\\|})     # must be preceded by nonword character, and not by escape or } (attribute)
+      ("`)(?=\S[\S ]*\S`"\W) # must be followed by inline characters and closed
+    beginCaptures:
+      '1': {name: support.variable.attributelist.asciidoc}
+      '2': {name: punctuation.definition.typographic-quotes.double.begin.asciidoc}
+    end: |-
+      (?x)
+      (`")
+      (?!\w) # must be followed by a nonword character
+    endCaptures:
+      '1': {name: punctuation.definition.typographic-quotes.double.begin.asciidoc}
+    patterns:
+    - include: '#typographic_quotes_single'
     - include: '#passthrough'
     - include: '#strong_double'
     - include: '#emphasis_double'
@@ -453,6 +529,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.bold.double.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#emphasis_double'
     - include: '#monospaced_double'
     - include: '#mark_double'
@@ -485,6 +563,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.italic.double.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#monospaced_double'
     - include: '#mark_double'
@@ -517,6 +597,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.literal.double.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#emphasis_double'
     - include: '#mark_double'
@@ -549,6 +631,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.string.unquoted.double.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#emphasis_double'
     - include: '#monospaced_double'
@@ -601,6 +685,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.bold.single.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#emphasis_double'
     - include: '#monospaced_double'
     - include: '#mark_double'
@@ -635,6 +721,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.italic.single.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#monospaced_double'
     - include: '#mark_double'
@@ -669,6 +757,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.literal.single.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#emphasis_double'
     - include: '#mark_double'
@@ -703,6 +793,8 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.string.unquoted.single.end.asciidoc}
     patterns:
+    - include: '#typographic_quotes_single'
+    - include: '#typographic_quotes_double'
     - include: '#strong_double'
     - include: '#emphasis_double'
     - include: '#monospaced_double'

--- a/syntaxes/Asciidoctor.tmLanguage
+++ b/syntaxes/Asciidoctor.tmLanguage
@@ -933,6 +933,14 @@ Examples:
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#strong_double</string>
 				</dict>
 				<dict>
@@ -1012,6 +1020,14 @@ Examples:
 			<string>markup.italic.double.asciidoc</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#strong_double</string>
@@ -1147,6 +1163,14 @@ Examples:
 		<dict>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#passthrough</string>
@@ -1525,6 +1549,14 @@ Examples:
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#strong_double</string>
 				</dict>
 				<dict>
@@ -1604,6 +1636,14 @@ Examples:
 			<string>string.other.unquoted.double.asciidoc</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#strong_double</string>
@@ -1689,6 +1729,14 @@ Examples:
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#strong_double</string>
 				</dict>
 				<dict>
@@ -1768,6 +1816,14 @@ Examples:
 			<string>string.other.literal.double.asciidoc</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#strong_double</string>
@@ -2018,6 +2074,14 @@ Examples:
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#emphasis_double</string>
 				</dict>
 				<dict>
@@ -2097,6 +2161,14 @@ Examples:
 			<string>markup.bold.double.asciidoc</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#emphasis_double</string>
@@ -2426,6 +2498,202 @@ Examples:
 			<string>^(======) (\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.5.asciidoc</string>
+		</dict>
+		<key>typographic_quotes_double</key>
+		<dict>
+			<key>begin</key>
+			<string>(?x)
+(\[[^\]]*?\])?         # might be preceded by an attributes list
+(?&lt;=^|\W)(?&lt;!\\|})     # must be preceded by nonword character, and not by escape or } (attribute)
+("`)(?=\S[\S ]*\S`"\W) # must be followed by inline characters and closed</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.variable.attributelist.asciidoc</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.typographic-quotes.double.begin.asciidoc</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Typographic quotes double.
+
+Examples:
+  "`Text`"
+</string>
+			<key>contentName</key>
+			<string>markup.italicinner.quote.typographic-quotes.double.asciidoc</string>
+			<key>end</key>
+			<string>(?x)
+(`")
+(?!\w) # must be followed by a nonword character</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.typographic-quotes.double.begin.asciidoc</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>markup.italic.quote.typographic-quotes.double.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#passthrough</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strong_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#emphasis_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#monospaced_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mark_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strong</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#emphasis</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#monospaced</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mark</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#superscript</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#subscript</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
+			</array>
+		</dict>
+		<key>typographic_quotes_single</key>
+		<dict>
+			<key>begin</key>
+			<string>(?x)
+(\[[^\]]*?\])?         # might be preceded by an attributes list
+(?&lt;=^|\W)(?&lt;!\\|})     # must be preceded by nonword character, and not by escape or } (attribute)
+('`)(?=\S[\S ]*\S`'\W) # must be followed by inline characters and closed</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.variable.attributelist.asciidoc</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.typographic-quotes.single.begin.asciidoc</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Typographic quotes single.
+
+Examples:
+  '`Text`'
+</string>
+			<key>contentName</key>
+			<string>markup.italicinner.quote.typographic-quotes.single.asciidoc</string>
+			<key>end</key>
+			<string>(?x)
+(`')
+(?!\w) # must be followed by a nonword character</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.typographic-quotes.single.begin.asciidoc</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>markup.italic.quote.typographic-quotes.single.asciidoc</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#passthrough</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strong_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#emphasis_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#monospaced_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mark_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strong</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#emphasis</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#monospaced</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mark</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#superscript</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#subscript</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
+			</array>
 		</dict>
 		<key>ulist_item_marker</key>
 		<dict>

--- a/syntaxes/Asciidoctor.tmLanguage
+++ b/syntaxes/Asciidoctor.tmLanguage
@@ -975,6 +975,10 @@ Examples:
 					<key>include</key>
 					<string>#characters</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
 			</array>
 		</dict>
 		<key>emphasis_double</key>
@@ -1063,6 +1067,10 @@ Examples:
 				<dict>
 					<key>include</key>
 					<string>#characters</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
 				</dict>
 			</array>
 		</dict>
@@ -1680,6 +1688,10 @@ Examples:
 					<key>include</key>
 					<string>#characters</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
 			</array>
 		</dict>
 		<key>monospaced</key>
@@ -1771,6 +1783,10 @@ Examples:
 					<key>include</key>
 					<string>#characters</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
 			</array>
 		</dict>
 		<key>monospaced_double</key>
@@ -1859,6 +1875,10 @@ Examples:
 				<dict>
 					<key>include</key>
 					<string>#characters</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
 				</dict>
 			</array>
 		</dict>
@@ -2116,6 +2136,10 @@ Examples:
 					<key>include</key>
 					<string>#characters</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
 			</array>
 		</dict>
 		<key>strong_double</key>
@@ -2205,6 +2229,10 @@ Examples:
 					<key>include</key>
 					<string>#characters</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
 			</array>
 		</dict>
 		<key>subscript</key>
@@ -2291,6 +2319,10 @@ Examples:
 					<key>include</key>
 					<string>#characters</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
+				</dict>
 			</array>
 		</dict>
 		<key>superscript</key>
@@ -2376,6 +2408,10 @@ Examples:
 				<dict>
 					<key>include</key>
 					<string>#characters</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#mail</string>
 				</dict>
 			</array>
 		</dict>

--- a/syntaxes/Asciidoctor.tmLanguage
+++ b/syntaxes/Asciidoctor.tmLanguage
@@ -2281,6 +2281,14 @@ Examples:
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#strong_double</string>
 				</dict>
 				<dict>
@@ -2369,6 +2377,14 @@ Examples:
 			<string>string.other.superscript.asciidoc</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#typographic_quotes_double</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#strong_double</string>


### PR DESCRIPTION
# Syntax
Typographic quotes have been added, both ```"`double`"``` and ```'`single`'```.

# script/build
The script now accepts arguments and can do single operations without having to do the whole building:
- `-h`, `--help`, `help`
    1. show help message
- `build` 
    1. install local node dependencies
    2. install global node dependencies
    3. generate the .tmLanguage file
    4. package the extension
- `npm`
    1. install local node dependencies
    2. install global node dependencies
- `npm_local`, `npm_local_deps`
    1. install local node dependencies
- `npm_global`, `npm_global_deps`
    1. install global node dependencie
- `generate`, `generate_syntax`
    1. generate the .tmLanguage file
- `package`
    1. package the extension
- `install`
    1. install the extension

If no argument is passed then the help message is shown.

These operations can be chained (e.g. `./script/build build install`).

I've explored the possibility of using a makefile, but the YAML to plist script would still need to be run as a separate script, so we might as well keep the bash script.

# Fixes
Email patterns are now recognized inside other inline patterns (bold, italic, etc...)

Indentation in package.json has been "fixed" (i.e. `npm install` has changed it to follow its own guidelines). Only a few lines were changed.