### PR TITLE
To fix a problem when preview multiple files in multiple folders with plantuml

### DIFF
--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -95,7 +95,7 @@ export class AsciiDocParser {
     private async convert_using_application(text: string) {
         const editor = vscode.window.activeTextEditor;
         const doc = editor.document;
-        const documentPath = path.dirname(this.filename).replace('"', '\\"');
+        const documentPath = path.dirname(doc.fileName).replace('"', '\\"');
         this.document = null;
 
         return new Promise<string>(resolve => {


### PR DESCRIPTION
Hello,
I am always helped by this useful tool.

Problem:

When open multiple asciidoc files with separated folders, and use with plantuml in indivisual asciidoc files, all diagram images output to same folder.
And preview of one file don't output plantuml image.

Screenshot:
<img width="915" alt="preview_folder_a" src="https://user-images.githubusercontent.com/8804566/51315937-b70cd980-1a96-11e9-8d7b-90cc1562ddc5.png">

<img width="915" alt="preview_folder_b" src="https://user-images.githubusercontent.com/8804566/51315947-baa06080-1a96-11e9-91bf-55831c8e4fe5.png">

Cause and pull request:

It seems that setting of documentpath  (in convert_using_application) is a cause of this problem.
After fixed it, works fine.

<img width="768" alt="preview_folder_a" src="https://user-images.githubusercontent.com/8804566/51315999-d572d500-1a96-11e9-83f4-e29f8fa9a269.png">

<img width="768" alt="preview_folder_b" src="https://user-images.githubusercontent.com/8804566/51316002-d73c9880-1a96-11e9-8b6b-04d40e161b95.png">

Could you check this pull request? 

Thank you for taking your time.