### PR TITLE
resolves #175 set RUBYOPT='-E UTF-8' when invoking the asciidoctor command

### DIFF
--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -100,7 +100,7 @@ export class AsciiDocParser {
 
         return new Promise<string>(resolve => {
             let asciidoctor_command = vscode.workspace.getConfiguration('asciidoc').get('asciidoctor_command', 'asciidoctor');
-            var options = { shell: true, cwd: path.dirname(this.filename) }
+            var options = { shell: true, cwd: path.dirname(this.filename), env: { ...process.env, RUBYOPT: '-E UTF-8' } }
 
             var adoc_cmd_array = asciidoctor_command.split(/(\s+)/).filter( function(e) { return e.trim().length > 0; } ) ;
             var adoc_cmd = adoc_cmd_array[0]


### PR DESCRIPTION
This change is required for the `asciidoctor` command in Asciidoctor 2.0 to work properly on a system that configures Ruby to use an IO encoding other than UTF-8.