### PR TITLE
Add basic symbol provider

### DIFF
--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -60,11 +60,10 @@ export class AsciidocEngine {
 	}
 
 	public async parse(document: vscode.Uri, source: string): Promise<any> {
-		// const { text, offset } = this.stripFrontmatter(source);
 		this.currentDocument = document;
-        // const engine = await this.getEngine(document);
-
-        return await {};
+		const engine = await this.getEngine(document);
+		let ascii_doc = await engine.parseText(source)
+		return engine.document
 	}
 
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { CommandManager } from './commandManager';
 import * as commands from './commands/index';
 import LinkProvider from './features/documentLinkProvider';
-import MDDocumentSymbolProvider from './features/documentSymbolProvider';
+import AdocDocumentSymbolProvider from './features/documentSymbolProvider';
 import AsciidocFoldingProvider from './features/foldingProvider';
 import { AsciidocContentProvider } from './features/previewContentProvider';
 import { AsciidocPreviewManager } from './features/previewManager';
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
 	];
 
 	const contentProvider = new AsciidocContentProvider(engine, context, cspArbiter, contributions, logger);
-	const symbolProvider = new MDDocumentSymbolProvider(engine);
+	const symbolProvider = new AdocDocumentSymbolProvider(engine);
     const previewManager = new AsciidocPreviewManager(contentProvider, logger, contributions);
 	context.subscriptions.push(previewManager);
 

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -13,7 +13,7 @@ interface AsciidocSymbol {
 	readonly children: vscode.DocumentSymbol[];
 }
 
-export default class MDDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+export default class AdocDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 
 	constructor(
 		private readonly engine: AsciidocEngine
@@ -54,7 +54,7 @@ export default class MDDocumentSymbolProvider implements vscode.DocumentSymbolPr
 
 	private toSymbolInformation(entry: TocEntry): vscode.SymbolInformation {
 		return new vscode.SymbolInformation(
-			this.getSymbolName(entry),
+			entry.text,
 			vscode.SymbolKind.String,
 			'',
 			entry.location);
@@ -62,14 +62,11 @@ export default class MDDocumentSymbolProvider implements vscode.DocumentSymbolPr
 
 	private toDocumentSymbol(entry: TocEntry) {
 		return new vscode.DocumentSymbol(
-			this.getSymbolName(entry),
+			entry.text,
 			'',
 			vscode.SymbolKind.String,
 			entry.location.range,
 			entry.location.range);
 	}
 
-	private getSymbolName(entry: TocEntry): string {
-		return '#'.repeat(entry.level) + ' ' + entry.text;
-	}
 }

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { disposeAll } from '../util/dispose';
 import { isAsciidocFile } from '../util/file';
 import { Lazy, lazy } from '../util/lazy';
-import MDDocumentSymbolProvider from './documentSymbolProvider';
+import AdocDocumentSymbolProvider from './documentSymbolProvider';
 import { SkinnyTextDocument } from '../tableOfContentsProvider';
 
 export interface WorkspaceAsciidocDocumentProvider {
@@ -104,7 +104,7 @@ export default class AsciidocWorkspaceSymbolProvider implements vscode.Workspace
 	private _disposables: vscode.Disposable[] = [];
 
 	public constructor(
-		private _symbolProvider: MDDocumentSymbolProvider,
+		private _symbolProvider: AdocDocumentSymbolProvider,
 		private _workspaceAsciidocDocumentProvider: WorkspaceAsciidocDocumentProvider = new VSCodeWorkspaceAsciidocDocumentProvider()
 	) { }
 

--- a/src/test/workspaceSymbolProvider.test.ts
+++ b/src/test/workspaceSymbolProvider.test.ts
@@ -6,13 +6,13 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import MDDocumentSymbolProvider from '../features/documentSymbolProvider';
+import AdocDocumentSymbolProvider from '../features/documentSymbolProvider';
 import AsciidocWorkspaceSymbolProvider, { WorkspaceAsciidocDocumentProvider } from '../features/workspaceSymbolProvider';
 import { createNewAsciidocEngine } from './engine';
 import { InMemoryDocument } from './inMemoryDocument';
 
 
-const symbolProvider = new MDDocumentSymbolProvider(createNewAsciidocEngine());
+const symbolProvider = new AdocDocumentSymbolProvider(createNewAsciidocEngine());
 
 suite('asciidoc.WorkspaceSymbolProvider', () => {
 	test('Should not return anything for empty workspace', async () => {


### PR DESCRIPTION
This PR closes #224 and restores fairly basic symbol support which I think has been missing since the extension got "upgraded" to the latest markdown extension state. It turns out not very much had to occur to achieve this.

I was unsure whether this same information could be retrieved from the syntax highlighter, but I struggled to find help with this so I chose to retrieve the information using `asciidoctor.js`.

I'd be grateful for any review and am happy to make changes (or for maintainers to make changes as they see fit).

In particular, do we need to [parse](https://github.com/asciidoctor/asciidoctor-vscode/compare/master...danyill:issue-224-no-symbols?expand=1#diff-69a778434b0c8db8bf46d9a9321af4ddR65) the document again or can we use an existing AST/model (i.e. just re-use `engine.document`). I suspect not (always). However this does mean that generating symbols/rendering may be heavier than necessary.

My Javascript is at a fairly basic stage. This won't work for non-Javascript engines. I have not updated the README or any feature list but can if this would be helpful.
