### PR TITLE
Additional snippets for quote block and footnote

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -206,5 +206,26 @@
 			"$0"
 		],
 		"description": "Insert tagged block"
+    },
+    "Insert quote block": {
+        "prefix": "quote",
+		"body": [
+            "[quote, ${1:citation}, ${2:cite}]",
+			"____",
+			"${3:${TM_SELECTED_TEXT:quote}}",
+			"____",
+			"$0"
+		],
+		"description": "Insert quote block"
+    },
+    "Insert footnote": {
+        "prefix": "footnote",
+        "body": "footnote:[${1:note}]",
+        "description": "Insert footnote"
+    },
+    "Insert footnote with label": {
+        "prefix": "footnote",
+        "body": "footnote:${1:label}[${2:note}]",
+        "description": "Insert footnote with label"
     }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -210,7 +210,7 @@
     "Insert quote block": {
         "prefix": "quote",
 		"body": [
-            "[quote, ${1:citation}, ${2:cite}]",
+            "[quote, ${1:attribution}, ${2:cite title}]",
 			"____",
 			"${3:${TM_SELECTED_TEXT:quote}}",
 			"____",
@@ -224,7 +224,7 @@
         "description": "Insert footnote"
     },
     "Insert footnote with label": {
-        "prefix": "footnote",
+        "prefix": "footnote-label",
         "body": "footnote:${1:label}[${2:note}]",
         "description": "Insert footnote with label"
     }


### PR DESCRIPTION
I've just added additional snippets for the `quote` block and for `footnote`. Up to now these were missing. Regarding the footnotes I ended up with two entries: one without and one with label. Most often I'm using the footnotes without label, therefore I don't want to remove the label each time.