### PR TITLE
Add code to ensure SymbolProvider not called too frequently,

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
 	];
 
 	const contentProvider = new AsciidocContentProvider(engine, context, cspArbiter, contributions, logger);
-	const symbolProvider = new AdocDocumentSymbolProvider(engine);
+	const symbolProvider = new AdocDocumentSymbolProvider(engine, null, null, null, null);
     const previewManager = new AsciidocPreviewManager(contentProvider, logger, contributions);
 	context.subscriptions.push(previewManager);
 

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -24,7 +24,7 @@ export default class AdocDocumentSymbolProvider implements vscode.DocumentSymbol
 		},
 		private lastSymbolCall: number,
 		private lastRunTime: number = 1000,
-		private RunTimeFactor: number = 5
+		private RunTimeFactor: number = 1.5
 	) { }
 
 	public async provideDocumentSymbolInformation(document: SkinnyTextDocument): Promise<vscode.SymbolInformation[]> {
@@ -34,7 +34,7 @@ export default class AdocDocumentSymbolProvider implements vscode.DocumentSymbol
 
 	public async provideDocumentSymbols(document: SkinnyTextDocument): Promise<vscode.DocumentSymbol[]> {
 
-		const nextOKRunTime = this.lastSymbolCall + this.lastRunTime * this.RunTimeFactor;
+		const nextOKRunTime = this.lastSymbolCall + Math.max(this.lastRunTime * this.RunTimeFactor, 2000);
 		const startTime = (new Date()).getTime();
 		
 		if (this.lastSymbolCall == undefined || startTime > nextOKRunTime) {

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -16,7 +16,15 @@ interface AsciidocSymbol {
 export default class AdocDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 
 	constructor(
-		private readonly engine: AsciidocEngine
+		private readonly engine: AsciidocEngine,
+		private root: AsciidocSymbol = {
+			level: -Infinity,
+			children: [],
+			parent: undefined
+		},
+		private lastSymbolCall: number,
+		private lastRunTime: number = 1000,
+		private RunTimeFactor: number = 5
 	) { }
 
 	public async provideDocumentSymbolInformation(document: SkinnyTextDocument): Promise<vscode.SymbolInformation[]> {
@@ -25,14 +33,26 @@ export default class AdocDocumentSymbolProvider implements vscode.DocumentSymbol
 	}
 
 	public async provideDocumentSymbols(document: SkinnyTextDocument): Promise<vscode.DocumentSymbol[]> {
-		const toc = await new TableOfContentsProvider(this.engine, document).getToc();
-		const root: AsciidocSymbol = {
-			level: -Infinity,
-			children: [],
-			parent: undefined
-		};
-		this.buildTree(root, toc);
-		return root.children;
+
+		const nextOKRunTime = this.lastSymbolCall + this.lastRunTime * this.RunTimeFactor;
+		const startTime = (new Date()).getTime();
+		
+		if (this.lastSymbolCall == undefined || startTime > nextOKRunTime) {
+
+			const toc = await new TableOfContentsProvider(this.engine, document).getToc();
+			this.root = {
+				level: -Infinity,
+				children: [],
+				parent: undefined
+				}
+			this.buildTree(this.root, toc);
+
+			this.lastSymbolCall = (new Date).getTime();
+			this.lastRunTime = this.lastSymbolCall - startTime;
+
+		}
+
+		return this.root.children;
 	}
 
 	private buildTree(parent: AsciidocSymbol, entries: TocEntry[]) {

--- a/src/test/documentSymbolProvider.test.ts
+++ b/src/test/documentSymbolProvider.test.ts
@@ -16,7 +16,7 @@ const testFileName = vscode.Uri.file('test.md');
 
 function getSymbolsForFile(fileContents: string) {
 	const doc = new InMemoryDocument(testFileName, fileContents);
-	const provider = new SymbolProvider(createNewAsciidocEngine());
+	const provider = new SymbolProvider(createNewAsciidocEngine(), null, null, null, null);
 	return provider.provideDocumentSymbols(doc);
 }
 

--- a/src/test/workspaceSymbolProvider.test.ts
+++ b/src/test/workspaceSymbolProvider.test.ts
@@ -12,7 +12,7 @@ import { createNewAsciidocEngine } from './engine';
 import { InMemoryDocument } from './inMemoryDocument';
 
 
-const symbolProvider = new AdocDocumentSymbolProvider(createNewAsciidocEngine());
+const symbolProvider = new AdocDocumentSymbolProvider(createNewAsciidocEngine(), null, null, null, null);
 
 suite('asciidoc.WorkspaceSymbolProvider', () => {
 	test('Should not return anything for empty workspace', async () => {


### PR DESCRIPTION
Closes #238 

I'm not too familiar with TypeScript interfaces so I've added several null arguments to allow the new class variables to retained.

I'd be very pleased for a review and happy to make any changes.

*What this does:*

Previously on some machines it was found that this extension with the recently added symbol/outline view (in v 2.7.7, #234) would cause them to go very slowly (see #238).

This seems to be because the new outline view uses Asciidoctor.js to produce the outline and takes the sections from the AST. VS code fires `provideDocumentSymbols` frequently and if the processing time from Asciidoctor.js is slow than the calling rate from VS code then a queue of asynchronous `provideDocumentSymbols` start to grow. This can then use significant CPU capacity and starve other processes as the user types. The queue then clears slowly.

I've changed the way the extension runs so that initially on load it produces an outline. It then records the processing time to produce the outline and will not produce an outline more frequently than `RunTimeFactor`, here set to 3.

I've tested this on a couple of Linux computers using the following version of code:

```
1.41.0
9579eda04fdb3a9bba2750f15193e5fafe16b959
x64
```

I find that the CPU goes down almost immediately after ceasing typing which is the desired effect. I have not metricated this using the debugger tools in code.

It would be good to test this on a variety of documents before we merge.