### PR TITLE
Disable folding provider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { CommandManager } from './commandManager';
 import * as commands from './commands/index';
 import LinkProvider from './features/documentLinkProvider';
 import AdocDocumentSymbolProvider from './features/documentSymbolProvider';
-import AsciidocFoldingProvider from './features/foldingProvider';
+// import AsciidocFoldingProvider from './features/foldingProvider';
 import { AsciidocContentProvider } from './features/previewContentProvider';
 import { AsciidocPreviewManager } from './features/previewManager';
 import AsciidocWorkspaceSymbolProvider from './features/workspaceSymbolProvider';
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider));
 	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()));
-	context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(selector, new AsciidocFoldingProvider(engine)));
+	// context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(selector, new AsciidocFoldingProvider(engine)));
 	context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new AsciidocWorkspaceSymbolProvider(symbolProvider)));
 
 	const previewSecuritySelector = new PreviewSecuritySelector(cspArbiter, previewManager);


### PR DESCRIPTION
Currently we get this error.

```
ERR tokens.filter is not a function: TypeError: tokens.filter is not a function
	at AsciidocFoldingProvider.<anonymous> (/home/mulhollandd/.vscode/extensions/joaompinto.asciidoctor-vscode-2.7.7/out/src/features/foldingProvider.js:29:42)
	at Generator.next (<anonymous>)
	at fulfilled (/home/mulhollandd/.vscode/extensions/joaompinto.asciidoctor-vscode-2.7.7/out/src/features/foldingProvider.js:8:58)
```

A foldingProvider is not implemented properly. This error has been present for a while and can be seen under the Developer Tools. This PR disables this code path.

