### PR TITLE
WIP: Intellisense autocompletion for Asciidoc attributes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { AsciidocEngine } from './asciidocEngine';
 import { getAsciidocExtensionContributions } from './asciidocExtensions';
 import { ExtensionContentSecurityPolicyArbiter, PreviewSecuritySelector } from './security';
 import { githubSlugifier } from './slugify';
+import { AttributeCompleter } from './features/attributeCompleter';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -41,6 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()));
 	// context.subscriptions.push(vscode.languages.registerFoldingRangeProvider(selector, new AsciidocFoldingProvider(engine)));
 	context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new AsciidocWorkspaceSymbolProvider(symbolProvider)));
+	context.subscriptions.push(vscode.languages.registerCompletionItemProvider(selector, new AttributeCompleter(), '{'));
 
 	const previewSecuritySelector = new PreviewSecuritySelector(cspArbiter, previewManager);
 

--- a/src/features/attributeCompleter.ts
+++ b/src/features/attributeCompleter.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+import { AsciidocParser } from '../text-parser';
+
+export class AttributeCompleter {
+
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
+
+        const adoc = new AsciidocParser(document.uri.fsPath)
+        adoc.parseText(document.getText())
+
+        let attribs = []
+        for (const [key, value] of Object.entries(adoc.document.getAttributes()))
+        {
+            let attrib = new vscode.CompletionItem(key, vscode.CompletionItemKind.Variable)
+            attrib.detail = value.toString()
+            attribs.push(attrib)
+        }
+
+        return attribs
+
+    }
+}

--- a/src/features/attributeCompleter.ts
+++ b/src/features/attributeCompleter.ts
@@ -8,12 +8,12 @@ export class AttributeCompleter {
 
         const adoc = new AsciidocParser(document.uri.fsPath)
         adoc.parseText(document.getText())
-
+        const attributes = adoc.document.getAttributes()
         let attribs = []
-        for (const [key, value] of Object.entries(adoc.document.getAttributes()))
-        {
+        
+        for (const key in attributes) {
             let attrib = new vscode.CompletionItem(key, vscode.CompletionItemKind.Variable)
-            attrib.detail = value.toString()
+            attrib.detail = attributes[key].toString()
             attribs.push(attrib)
         }
 


### PR DESCRIPTION
I have long wanted to write a `{` and a few characters and see the attribute and value.

This PR implements basic support for this and I think it is complete but could do with some testing.