### PR TITLE
Prepare for compatibility with asciidoctor-pdf.js, related to #239

### DIFF
--- a/src/commands/exportAsPDF.ts
+++ b/src/commands/exportAsPDF.ts
@@ -58,9 +58,9 @@ export class ExportAsPDF implements Command {
             var adocpdf_cmd = adocpdf_cmd_array[0]
 
             var adocpdf_cmd_args = adocpdf_cmd_array.slice(1)
-            adocpdf_cmd_args.push.apply(adocpdf_cmd_args, ['-q', '-',
+            adocpdf_cmd_args.push.apply(adocpdf_cmd_args, ['-q',
                 '-B', '"' + docPath.dir.replace('"', '\\"') + '"',
-                '-o', '"' + pdfPath.replace('"', '\\"') + '"'
+                '-o', '"' + pdfPath.replace('"', '\\"') + '"', '-'
             ])
 
             var options = { shell: true, cwd: docPath.dir }


### PR DESCRIPTION
I'd like this extension to be able to support asciidoctor-pdf.js 

Support for reading from stdin was recently added but the @asciidoctor/cli requires that the stdin argument be the last one. So this PR simply moves this argument to the end which has no impact on asciidoctor-pdf (Ruby).

See https://github.com/Mogztter/asciidoctor-pdf.js/issues/155 for details.