### PR TITLE
Add classes from <body> in Asciidoctor output to webview document

### DIFF
--- a/src/features/previewContentProvider.ts
+++ b/src/features/previewContentProvider.ts
@@ -68,6 +68,9 @@ export class AsciidocContentProvider {
 		const nonce = new Date().getTime() + '' + new Date().getMilliseconds();
 		const csp = this.getCspForResource(sourceUri, nonce);
 		const body = await this.engine.render(sourceUri, config.previewFrontMatter === 'hide', asciidocDocument.getText());
+
+		const bodyClassesRegex = /<body(?:(?:\s+class(?:\s*=\s*(?:\"(.+?)\"|\'(.+?)\')))+\s*)>/
+		const bodyClasses = body.match(bodyClassesRegex)
 		return `<!DOCTYPE html>
 			<html>
 			<head>
@@ -81,7 +84,7 @@ export class AsciidocContentProvider {
 				${this.getStyles(sourceUri, nonce, config, state)}
 				<base href="${asciidocDocument.uri.with({ scheme: 'vscode-resource' }).toString(true)}">
 			</head>
-			<body class="vscode-body ${config.scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${config.wordWrap ? 'wordWrap' : ''} ${config.markEditorSelection ? 'showEditorSelection' : ''}">
+			<body class="${bodyClasses[1]} vscode-body ${config.scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${config.wordWrap ? 'wordWrap' : ''} ${config.markEditorSelection ? 'showEditorSelection' : ''}">
 				${body}
 				<div class="code-line" data-line="${asciidocDocument.lineCount}"></div>
 				<script async src="${this.extensionResourcePath('index.js')}" nonce="${nonce}" charset="UTF-8"></script>


### PR DESCRIPTION
Closes #141 

The core problem is that classes on the `<body>` element are missing which means the default asciidoctor stylesheet is not functioning correctly resulting in the sidebars associated with the table of contents not presenting as user's expect (being on top of the text).

A normal Asciidoctor document with `:toc: left` might look like this:

![image](https://user-images.githubusercontent.com/674783/73572856-c363a900-44d6-11ea-8e3e-63f37d66a1da.png)

The way we process Asciidoctor content is by rendering it from the lines of the source document and then fitting it into a template expression. Probably we should be using the embedded option (see [here](https://asciidoctor.org/docs/user-manual/#using-a-toc-with-embeddable-html)) and then handling the table of contents in a different fashion (by templating it and styling it specific to this extension).

I think (but am not sure) that the `<body>` element of the Asciidoctor output is being removed (not sure by what) so that only the top-level (actually second level) `<body>` element exists. I'm not sure if this is done in this extension or by the VS Code html parser (I think this is invalid html "strictly" speaking). This is then having the unintended affect of removing the classes necessary to make the table of contents function correctly.

So the DOM for the preview output looks like:

![image](https://user-images.githubusercontent.com/674783/73573621-ac25bb00-44d8-11ea-906a-08115c49f1a8.png)

Note that there is two `<body>` tags, the second in the `<iframe>` but the third (!) `<body>` tag provided by L#70 and L#85 is missing in the output.

https://github.com/asciidoctor/asciidoctor-vscode/blob/db4a1d125fae2b22552d5c1056848213162781e7/src/features/previewContentProvider.ts#L70-L90

This PR provides a somewhat "hacky" fix which is to use a (hopefully narrowly scoped) regex to pick up the Asciidoctor output `<body>` classes and put them into the output html. I have done this because otherwise we would need to parse into a DOM for which we currently don't require any libraries and it would take significant time. However using a regex for this is very likely brittle and may cause other problems.

I've tested this with `:toc: right|left|auto|macro` and it appears to work, but I'd appreciate others carrying out some tests.

Happy to work on a better solution if someone can provide a few suggestions on an alternative approach.
