### PR TITLE
Use safe_load to avoid warning

### DIFF
--- a/script/yaml-to-plist.py
+++ b/script/yaml-to-plist.py
@@ -26,4 +26,4 @@ out_path = sys.argv[2]
 
 with open(in_path, 'r', encoding='utf-8') as in_file:
     with open(out_path, 'w', encoding='utf-8') as out_file:
-        out_file.writelines(convert(yaml.load(in_file)))
+        out_file.writelines(convert(yaml.safe_load(in_file)))


### PR DESCRIPTION
This PR just uses `safe_load` to avoid the error message in the script.

```bash
10:09 $ ./build.sh generate
==> Converting YAML syntax to plist
script/yaml-to-plist.py:30: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  out_file.writelines(convert(yaml.load(in_file)))
```

I've diffed the output with either method and both methods convert identically.