### PR TITLE
Fix Unicode characters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ All the following people who have contributed to the extension:
 * Johannes Rössel
 * Joshua Stafman
 * Kevin Palmowski
-* Loïc PÉRON
+* Loïc PÉRON
 * Marcelo Alvim
 * Mark Roszko
 * Masanori Asano


### PR DESCRIPTION
(See the conversation [here](https://github.com/asciidoctor/asciidoctor-vscode/pull/258#discussion_r373777196) for context.)

Two characters with diacritics in the README were changed in 6f387f0 from single characters to composite characters:

- ï (U+00EF = `C3 AF` in utf-8) became ï (U+0069 U+0308 = `69 CC 88` in utf-8)
- É (U+00C9 = `C3 89` in utf-8) became É (U+0045 U+0301 = `45 CC 81` in utf-8)

Note that the change did not affect other similar characters, such as `ö` (U+00F6), which remained in their non-composed forms.

This commit restores the two changed characters to the original ones.