### PR TITLE
Add shortcut key for paste image, clean up whitespace, ensure empty d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Change language definition to be the same as that of the Atom extension [atom-language-asciidoc](https://github.com/asciidoctor/atom-language-asciidoc/)
 * Support the source block (closes #212)
 * Support image pasting on Linux/Mac (closes #255)
+* Add Ctrl+Alt+V/Cmd+Alt+V (Mac) as shortcut key for image paste
 * Add `.png` extension automatically for image pasting
 
 ## 2.7.9

--- a/package.json
+++ b/package.json
@@ -223,6 +223,12 @@
 				"key": "ctrl+k v",
 				"mac": "cmd+k v",
 				"when": "editorLangId == asciidoc"
+			},
+			{
+				"command": "asciidoc.pasteImage",
+				"key": "ctrl+alt+v",
+				"mac": "cmd+alt+v",
+				"when": "editorLangId == asciidoc"
 			}
 		],
 		"configuration": {

--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -294,19 +294,9 @@ export namespace Import {
       index: number,
       selectedText: string
     ) {
-      let result = '';
-      switch (selectionMode) {
-        case SelectionMode.Insert:
-          result = affectedText;
-          break;
-        case SelectionMode.Replace:
-          result = affectedText.replace(selectedText, '');
-          break;
-      }
-
       // does the macro start at the beginning of the line and end in only
       // whitespace.
-      return !(index === 0 && /^\s+$/.test(result) || /^\s+$|^\S+$/.test(result))
+      return !(index === 0 && /^\s+$/.test(affectedText) || /^\s+$|^\S+$/.test(affectedText))
     }
 
     /**

--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -1,8 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ChildProcess, spawn, exec, spawnSync, execSync } from 'child_process';
+import { spawn } from 'child_process';
 import * as moment from 'moment';
-import { Uri } from 'vscode';
 import * as fs from 'fs';
 
 import { AsciidocParser } from './text-parser';
@@ -66,7 +65,7 @@ export namespace Import {
      */
     static saveImageFromClipboard(filename: string) {
       const platform = process.platform
-      if (platform === 'win32') { 
+      if (platform === 'win32') {
         const script = path.join(__dirname, '../../res/pc.ps1');
         let promise = new Promise((resolve, reject) => {
           let child = spawn('powershell', [
@@ -182,6 +181,13 @@ export namespace Import {
 
       try {
         const docDir = path.dirname(vscode.window.activeTextEditor.document.uri.fsPath)
+
+        // docDir === '.' if a document has not yet been saved
+        if (docDir === '.') {
+          vscode.window.showErrorMessage('To allow images to be saved, first save your document.')
+          return
+        }
+
         await this.saveImageFromClipboard(path.join(docDir, directory, filename));
       } catch (error) {
         if (error instanceof ScriptArgumentError) {
@@ -204,9 +210,9 @@ export namespace Import {
             );
           else if (error.message == 'no filename exception')
             vscode.window.showErrorMessage('Missing image filename argument.');
-          else if (error.message == 'no xclip') 
+          else if (error.message == 'no xclip')
             vscode.window.showErrorMessage('To use this feature you must install xclip');
-          } else 
+          } else
             vscode.window.showErrorMessage(error.toString());
         return;
       }
@@ -334,7 +340,7 @@ export namespace Import {
         dir = adoc.document.getAttribute('imagesdir')
       }
 
-      return dir;
+      return dir !== undefined ? dir : ''
     }
 
     /**


### PR DESCRIPTION
Add shortcut key for paste image, clean up whitespace, ensure empty document image save error message is clear

@joaompinto thanks for testing, this resolves your comment in https://github.com/asciidoctor/asciidoctor-vscode/pull/260#issuecomment-581779947

* tidies up unused references
* removes whitespace
* Adds a shortcut key for linux/mac (same as https://marketplace.visualstudio.com/items?itemName=mushan.vscode-paste-image)

Finally the prediction path for inline vs block images made no sense to me. Whether we are replacing or inserting text, if there is already text on a line (other than, say spaces) and other than a single "word" (which we need for when the user has provided a name for the image, we don't allow images with spaces) we should use the single `:` (inline image) otherwise we should use the block image (`::`). At least insofar as I understand it.

```
some text <selection "asdf"> ==> image:[]
<selection "one_word_image_filename"> ==> image::[]
```

On my machine for reasons which are unclear when debugging I get a JSON error with `package.json`. But I believe it to be valid JSON (web tools seem to agree) and the package builds properly. Perhaps you might know why this happens or be able to confirm this problem?