### PR TITLE
Add command to save the document HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.7.11
+
+* Add support for saving html output
+
 ## 2.7.10
 
 * Change language definition to be the same as that of the Atom extension [atom-language-asciidoc](https://github.com/asciidoctor/atom-language-asciidoc/)

--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ An extension that provides live preview, syntax highlighting and snippets for th
 
 ## Contents
 
-* [Contents](#contents)
-* [How to Install](#how-to-install)
-* [How to Use](#how-to-use)
-  * [Preview](#preview)
-  * [Export as PDF](#export-as-pdf)
-  * [Snippets](#snippets)
-* [Options](#options)
-* [Build and Install from Source](#build-and-install-from-source)
-  * [Manual](#manual)
-  * [Script](#script)
-* [Issues](#issues)
-* [Contributing](#contributing)
-* [Credits](#credits)
+- [AsciiDoc support for Visual Studio Code](#asciidoc-support-for-visual-studio-code)
+  - [Contents](#contents)
+  - [How to Install](#how-to-install)
+  - [How to Use](#how-to-use)
+    - [Preview](#preview)
+    - [Export as PDF](#export-as-pdf)
+    - [Save as HTML](#save-as-html)
+    - [Snippets](#snippets)
+  - [Options](#options)
+  - [Build and Install from Source](#build-and-install-from-source)
+    - [Manual](#manual)
+    - [Script](#script)
+  - [Issues](#issues)
+  - [Contributing](#contributing)
+  - [Credits](#credits)
 
 ## How to Install
 
@@ -61,6 +63,16 @@ The extension provides a quick command to export your AsciiDoc file as PDF.
 
 By default a separate binary is downloaded and used to render the document in PDF format. To use Asciidoctor PDF set option `asciidoc.use_asciidoctorpdf` to `true`.<br/>
 (See more details under [Options](#options))
+
+### Save as HTML
+
+The extension provides a quick command to export your AsciiDoc file as HTML using the default Asciidoctor stylesheet.
+
+* Open the command palette - `ctrl+shift+p` or `F1` (Mac: `cmd+shift+p`)
+* Select _AsciiDoc: Export document as HTML_
+* The file is generated in the same folder as the source document
+
+The shortcout key of `ctrl+alt+s` (Mac: `cmd+alt+s`) will also save the document.
 
 ### Snippets
 

--- a/media/SaveHTML.svg
+++ b/media/SaveHTML.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg3985"
+   sodipodi:docname="SaveHTML.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata3991">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3989" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     id="namedview3987"
+     showgrid="false"
+     inkscape:zoom="20.85965"
+     inkscape:cx="2.0011777"
+     inkscape:cy="8.8591434"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3985"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-page="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-global="true" />
+  <g
+     aria-label="HTML"
+     style="font-style:normal;font-weight:normal;font-size:5.32112837px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#00539c;fill-opacity:1;stroke:none;stroke-width:0.13302819"
+     id="text3721">
+    <path
+       d="M 4.3456626,4.7897997 V 3.1711166 H 3.2206388 V 4.7897997 H 2.4541677 V 1.00681 H 3.2206388 V 2.537154 H 4.3456626 V 1.00681 h 0.7612747 v 3.7829897 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed,  Bold';fill:#00539c;stroke-width:0.13302819"
+       id="path4126" />
+    <path
+       d="M 5.4758827,1.6433708 V 1.00681 H 8.0974738 V 1.6433708 H 7.159521 V 4.7897997 H 6.3956481 V 1.6433708 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed,  Bold';fill:#00539c;stroke-width:0.13302819"
+       id="path4128" />
+    <path
+       d="M 10.246191,3.740124 10.9581,1.00681 h 0.997712 V 4.7897997 H 11.18934 V 3.766106 l 0.07015,-1.5667189 -0.75348,2.5904126 H 9.9837722 L 9.2302922,2.1993871 9.3004437,3.766106 V 4.7897997 H 8.5339726 V 1.00681 h 0.9977116 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed,  Bold';fill:#00539c;stroke-width:0.13302819"
+       id="path4130" />
+    <path
+       d="M 14.670938,4.1558371 V 4.7897997 H 12.56639 V 1.00681 h 0.766472 v 3.1490271 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed,  Bold';fill:#00539c;stroke-width:0.13302819"
+       id="path4132" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     d="m 11.937867,8.937027 v 3.937868 H 4.062132 V 8.937027 H 2.937027 v 3.937868 C 2.937027,13.493702 3.443324,14 4.062132,14 h 7.875735 c 0.618807,0 1.125105,-0.506298 1.125105,-1.125105 V 8.937027 Z M 8.562553,9.313938 10.019563,7.862552 10.812762,8.655751 7.999999,11.468513 5.187238,8.655751 5.980436,7.862552 7.437447,9.313938 V 5.480026 h 1.125106 z"
+     id="path3808"
+     style="fill:#656565;stroke-width:0.56255251"
+     sodipodi:nodetypes="cccccsssscccccccccccc" />
+</svg>

--- a/media/SaveHTML_inverse.svg
+++ b/media/SaveHTML_inverse.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg3985"
+   sodipodi:docname="SaveHTML_inverse.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata3991">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3989" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     id="namedview3987"
+     showgrid="false"
+     inkscape:zoom="20.85965"
+     inkscape:cx="2.0011777"
+     inkscape:cy="8.8591434"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3985"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-page="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-global="true" />
+  <g
+     aria-label="HTML"
+     style="font-style:normal;font-weight:normal;font-size:5.32112837px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#75beff;fill-opacity:1;stroke:none;stroke-width:0.13302819"
+     id="text3721">
+    <path
+       d="M 4.3456626,4.7897997 V 3.1711166 H 3.2206388 V 4.7897997 H 2.4541677 V 1.00681 H 3.2206388 V 2.537154 H 4.3456626 V 1.00681 h 0.7612747 v 3.7829897 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed, Bold';fill:#75beff;stroke-width:0.13302819"
+       id="path4126" />
+    <path
+       d="M 5.4758827,1.6433708 V 1.00681 H 8.0974738 V 1.6433708 H 7.159521 V 4.7897997 H 6.3956481 V 1.6433708 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed, Bold';fill:#75beff;stroke-width:0.13302819"
+       id="path4128" />
+    <path
+       d="M 10.246191,3.740124 10.9581,1.00681 h 0.997712 V 4.7897997 H 11.18934 V 3.766106 l 0.07015,-1.5667189 -0.75348,2.5904126 H 9.9837722 L 9.2302922,2.1993871 9.3004437,3.766106 V 4.7897997 H 8.5339726 V 1.00681 h 0.9977116 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed, Bold';fill:#75beff;stroke-width:0.13302819"
+       id="path4130" />
+    <path
+       d="M 14.670938,4.1558371 V 4.7897997 H 12.56639 V 1.00681 h 0.766472 v 3.1490271 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Roboto Condensed';-inkscape-font-specification:'Roboto Condensed, Bold';fill:#75beff;stroke-width:0.13302819"
+       id="path4132" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     d="m 11.937867,8.937027 v 3.937868 H 4.062132 V 8.937027 H 2.937027 v 3.937868 C 2.937027,13.493702 3.443324,14 4.062132,14 h 7.875735 c 0.618807,0 1.125105,-0.506298 1.125105,-1.125105 V 8.937027 Z M 8.562553,9.313938 10.019563,7.862552 10.812762,8.655751 7.999999,11.468513 5.187238,8.655751 5.980436,7.862552 7.437447,9.313938 V 5.480026 h 1.125106 z"
+     id="path3808"
+     style="fill:#c5c5c5;stroke-width:0.56255251"
+     sodipodi:nodetypes="cccccsssscccccccccccc" />
+</svg>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"icon": "images/icon.png",
 	"main": "./out/src/extension",
 	"engines": {
-		"vscode": "^1.28.0"
+		"vscode": "^1.31.0"
 	},
 	"categories": [
 		"Programming Languages"
@@ -418,7 +418,6 @@
 		"compile": "tsc -watch -p ./ && npm run build-preview",
 		"vscode:prepublish": "tsc -p ./ && npm run build-preview",
 		"watch": "npm run build-preview && tsc -watch -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install",
 		"test": "node ./node_modules/vscode/bin/test",
 		"build-preview": "webpack --mode development"
 	},
@@ -433,12 +432,12 @@
 		"ts-loader": "^4.0.1",
 		"tslint": "^5.9.1",
 		"typescript": "^2.7.2",
-		"vscode": "^1.1.10",
 		"webpack": "^4.41.5",
 		"webpack-cli": "^3.1.1"
 	},
 	"dependencies": {
 		"@asciidoctor/core": "2.1.0",
+		"@types/vscode": "^1.31.0",
 		"asciidoctor-kroki": "^0.6.0",
 		"asciidoctor-plantuml": "1.5.0",
 		"copy-paste": "^1.3.0",
@@ -454,3 +453,4 @@
 		"vscode-nls": "^4.1.1"
 	}
 }
+

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"onCommand:asciidoc.pasteImage",
 		"onCommand:asciidoc.preview.toggleLock",
 		"onCommand:asciidoc.preview.refresh",
+		"onCommand:asciidoc.saveHTML",
 		"onCommand:asciidoc.showPreview",
 		"onCommand:asciidoc.showPreviewToSide",
 		"onCommand:asciidoc.showLockedPreviewToSide",
@@ -131,6 +132,15 @@
 				"command": "asciidoc.preview.toggleLock",
 				"title": "%asciidoc.preview.toggleLock.title%",
 				"category": "AsciiDoc"
+			},
+			{
+				"command": "asciidoc.saveHTML",
+				"title": "%asciidoc.saveHTML.title%",
+				"category": "AsciiDoc",
+				"icon": {
+					"light": "./media/SaveHTML.svg",
+					"dark": "./media/SaveHTML_inverse.svg"
+				}
 			}
 		],
 		"menus": {
@@ -228,6 +238,12 @@
 				"command": "asciidoc.pasteImage",
 				"key": "ctrl+alt+v",
 				"mac": "cmd+alt+v",
+				"when": "editorLangId == asciidoc"
+			},
+			{
+				"command": "asciidoc.saveHTML",
+				"key": "ctrl+alt+s",
+				"mac": "cmd+alt+s",
 				"when": "editorLangId == asciidoc"
 			}
 		],

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
 	"asciidoc.preview.refresh.title": "Refresh Preview",
 	"asciidoc.preview.toggleLock.title": "Toggle Preview Locking",
 	"asciidoc.previewSide.title": "Open Preview to the Side",
+	"asciidoc.saveHTML.title": "Save HTML document",
 	"asciidoc.showLockedPreviewToSide.title": "Open Locked Preview to the Side",
 	"asciidoc.showPreviewSecuritySelector.title": "Change Preview Security Settings",
 	"asciidoc.showSource.title": "Show Source",

--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -43,7 +43,7 @@ export class AsciidocEngine {
 		return { text, offset };
 	}
 
-	public async render(document: vscode.Uri, stripFrontmatter: boolean, text: string): Promise<string> {
+	public async render(document: vscode.Uri, stripFrontmatter: boolean, text: string, forHTML: boolean = false): Promise<string> {
 		let offset = 0;
 		if (stripFrontmatter) {
 			const asciidocContent = this.stripFrontmatter(text);
@@ -54,7 +54,7 @@ export class AsciidocEngine {
 		this.currentDocument = document;
 		this.firstLine = offset;
         const engine = await this.getEngine(document);
-        let ascii_doc = engine.parseText(text)
+        let ascii_doc = engine.parseText(text, forHTML)
         return ascii_doc;
 	}
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,4 +11,5 @@ export { MoveCursorToPositionCommand } from './moveCursorToPosition';
 export { ToggleLockCommand } from './toggleLock';
 export { ExportAsPDF } from './exportAsPDF';
 export { PasteImage} from './pasteImage';
+export { SaveHTML } from './saveHTML';
 

--- a/src/commands/saveHTML.ts
+++ b/src/commands/saveHTML.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode'
+import * as fs from 'fs'
+import * as path from 'path'
+import { isNullOrUndefined } from 'util'
+import { AsciidocParser } from '../text-parser'
+import { Command } from '../commandManager'
+import { AsciidocEngine } from '../asciidocEngine'
+
+export class SaveHTML implements Command {
+    public readonly id = 'asciidoc.saveHTML'
+
+	constructor(
+		private readonly engine: AsciidocEngine
+	) { }
+
+    public async execute() {
+        const editor = vscode.window.activeTextEditor
+        if(isNullOrUndefined(editor))
+            return
+
+        const doc = editor.document
+        const text = doc.getText()
+
+        const docPath = path.parse(path.resolve(doc.fileName))
+        let htmlPath
+
+        if (doc.isUntitled) {
+            htmlPath = path.join(docPath.root, docPath.dir, "untitled.html")
+        } else {
+            htmlPath = path.join(docPath.root, docPath.dir, docPath.name+".html")
+        }
+
+        let parser = new AsciidocParser(path.resolve(doc.fileName))
+        const html = await this.engine.render(doc.uri, true, text, true)
+
+        fs.writeFile(htmlPath, html, function(err) {
+            if(err) {
+                vscode.window.showErrorMessage('Error writing file ' + htmlPath + "\n" + err.toString())
+                return
+            }
+            vscode.window.showInformationMessage('Successfully converted to ', htmlPath)
+                .then(selection => {
+                    if (selection === htmlPath) {
+                        vscode.env.openExternal(vscode.Uri.parse(htmlPath))
+                    }
+                });    
+        });
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,8 @@ export function activate(context: vscode.ExtensionContext) {
     commandManager.register(new commands.ExportAsPDF(engine));
     commandManager.register(new commands.PasteImage());
 	commandManager.register(new commands.ToggleLockCommand(previewManager));
-    commandManager.register(new commands.ShowPreviewCommand(previewManager));
+	commandManager.register(new commands.ShowPreviewCommand(previewManager));
+	commandManager.register(new commands.SaveHTML(engine));
 
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
 		logger.updateConfiguration();

--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -61,7 +61,7 @@ export class AsciidocParser {
         return match;
     }
 
-    private async convert_using_javascript(text: string) {
+    private async convert_using_javascript(text: string, forHTMLSave: boolean) {
         return new Promise<string>(resolve => {
             const editor = vscode.window.activeTextEditor;
             const doc = editor.document;
@@ -94,7 +94,7 @@ export class AsciidocParser {
                 }
 
                 attributes = { 'copycss': true, 'stylesdir': stylesdir, 'stylesheet': stylesheet }
-            } else if (use_editor_stylesheet) {
+            } else if (use_editor_stylesheet && !forHTMLSave) {
                 attributes = { 'copycss': true, 'stylesdir': this.stylesdir, 'stylesheet': 'asciidoctor-editor.css' }
             } else {
                 // TODO: decide whether to use the included css or let ascidoctor.js decide
@@ -133,7 +133,7 @@ export class AsciidocParser {
         })
     }
 
-    private async convert_using_application(text: string) {
+    private async convert_using_application(text: string, forHTMLSave: boolean) {
         const editor = vscode.window.activeTextEditor;
         const doc = editor.document;
         const documentPath = path.dirname(doc.fileName).replace('"', '\\"');
@@ -182,7 +182,7 @@ export class AsciidocParser {
 
                 adoc_cmd_args.push.apply(adoc_cmd_args, ['-a', `stylesdir=${stylesdir}`])
                 adoc_cmd_args.push.apply(adoc_cmd_args, ['-a', `stylesheet=${stylesheet}`])
-            } else if (use_editor_stylesheet) {
+            } else if (use_editor_stylesheet && !forHTMLSave) {
                 adoc_cmd_args.push.apply(adoc_cmd_args, ['-a', `stylesdir=${this.stylesdir}@`])
                 adoc_cmd_args.push.apply(adoc_cmd_args, ['-a', 'stylesheet=asciidoctor-editor.css@'])
             } else {
@@ -248,12 +248,12 @@ export class AsciidocParser {
         return result;
     }
 
-    public async parseText(text: string): Promise<string> {
+    public async parseText(text: string, forHTMLSave: boolean = false): Promise<string> {
         const use_asciidoctor_js = vscode.workspace.getConfiguration('asciidoc', null).get('use_asciidoctor_js');
         if (use_asciidoctor_js)
-            return this.convert_using_javascript(text)
+            return this.convert_using_javascript(text, forHTMLSave)
         else
-            return this.convert_using_application(text)
+            return this.convert_using_application(text, forHTMLSave)
     }
 
 }


### PR DESCRIPTION
This PR adds a new command to save the document to HTML, normally using the default stylesheet unless the user has specified another (as opposed to the editor preview stylesheet).

Hopefully this is a useful addition. As always, happy to receive reviews/improve where requested.

I've updated the engine to support `vscode.env.openExternal` and done the migration to the newer package as per https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode (not for tests but for the rest).