### PR TITLE
Support URI encoded characters in anchors links, closes #281

### DIFF
--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -129,7 +129,10 @@ document.addEventListener('click', event => {
 	while (node) {
 		if (node.tagName && node.tagName === 'A' && node.href) {
 			if (node.getAttribute('href').startsWith('#')) {
-				break;
+				const fragment = node.href.split('#')[1];
+				if (fragment) {
+					location.hash = "#" + decodeURI(fragment);
+				}
 			}
 			if (node.href.startsWith('file://') || node.href.startsWith('vscode-resource:')) {
 				const [path, fragment] = node.href.replace(/^(file:\/\/|vscode-resource:)/i, '').split('#');


### PR DESCRIPTION
Links could not be followed if they were URI encoded, because there was no location for them to go to which was valid. This PR URI decodes the link (back to original) to allow the link to be followed in the client side preview code.