### PR TITLE
add basic eslint setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,31 @@
+module.exports = {
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "tsconfig.json",
+    "tsconfigRootDir": __dirname,
+    "sourceType": "module"
+  },
+  "extends": [
+//    "eslint:recommended",
+//    "plugin:@typescript-eslint/recommended",
+  ],
+  "rules": {
+    "arrow-parens": ["error", "always"],
+    /*
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline"
+    }],
+    */
+    "max-len": ["error", {
+      "code": 160,
+      "ignoreStrings": true,
+      "ignoreUrls": true,
+      "ignoreTemplateLiterals": true
+    }],
+    "spaced-comment": "off"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -439,8 +439,8 @@
 	"scripts": {
 		"compile": "tsc -watch -p ./ && npm run build-preview",
 		"vscode:prepublish": "tsc -p ./ && npm run build-preview",
-    "lint": "eslint src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
-    "lint:fix": "eslint --fix src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
+		"lint": "eslint src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
+		"lint:fix": "eslint --fix src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
 		"watch": "npm run build-preview && tsc -watch -p ./",
 		"test": "node ./node_modules/vscode/bin/test",
 		"build-preview": "webpack --mode development"

--- a/package.json
+++ b/package.json
@@ -439,6 +439,7 @@
 	"scripts": {
 		"compile": "tsc -watch -p ./ && npm run build-preview",
 		"vscode:prepublish": "tsc -p ./ && npm run build-preview",
+		"lint": "eslint src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
 		"watch": "npm run build-preview && tsc -watch -p ./",
 		"test": "node ./node_modules/vscode/bin/test",
 		"build-preview": "webpack --mode development"
@@ -448,12 +449,15 @@
 		"@types/lodash.throttle": "^4.1.3",
 		"@types/mocha": "^5.2.5",
 		"@types/node": "^8.10.25",
+		"@typescript-eslint/eslint-plugin": "^2.26.0",
+		"@typescript-eslint/parser": "^2.26.0",
+		"eslint": "^6.8.0",
+		"eslint-plugin-import": "^2.20.2",
 		"lodash.throttle": "^4.1.1",
 		"mocha-junit-reporter": "^1.23.3",
 		"mocha-multi-reporters": "^1.1.7",
 		"ts-loader": "^4.0.1",
-		"tslint": "^5.9.1",
-		"typescript": "^2.7.2",
+		"typescript": "^3.8.3",
 		"webpack": "^4.41.5",
 		"webpack-cli": "^3.1.1"
 	},

--- a/package.json
+++ b/package.json
@@ -439,7 +439,8 @@
 	"scripts": {
 		"compile": "tsc -watch -p ./ && npm run build-preview",
 		"vscode:prepublish": "tsc -p ./ && npm run build-preview",
-		"lint": "eslint src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
+    "lint": "eslint src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
+    "lint:fix": "eslint --fix src/**/*.ts preview-src/**/*.ts test/**/*.ts --format unix",
 		"watch": "npm run build-preview && tsc -watch -p ./",
 		"test": "node ./node_modules/vscode/bin/test",
 		"build-preview": "webpack --mode development"

--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -84,7 +84,7 @@ window.addEventListener('resize', () => {
 	updateImageSizes();
 }, true);
 
-window.addEventListener('message', event => {
+window.addEventListener('message', (event) => {
 	if (event.data.source !== settings.source) {
 		return;
 	}
@@ -101,7 +101,7 @@ window.addEventListener('message', event => {
 	}
 }, false);
 
-document.addEventListener('dblclick', event => {
+document.addEventListener('dblclick', (event) => {
 	if (!settings.doubleClickToSwitchToEditor) {
 		return;
 	}
@@ -120,7 +120,7 @@ document.addEventListener('dblclick', event => {
 	}
 });
 
-document.addEventListener('click', event => {
+document.addEventListener('click', (event) => {
 	if (!event) {
 		return;
 	}

--- a/src/commands/exportAsPDF.ts
+++ b/src/commands/exportAsPDF.ts
@@ -175,7 +175,7 @@ export class ExportAsPDF implements Command {
             if(!isNullOrUndefined(save_filename)) {
                 html2pdf(html, binary_path, cover, footer_center, save_filename.fsPath)
                 .then((result) => { offer_open(result) })
-                .catch(reason => {
+                .catch((reason) => {
                     console.error("Got error", reason)
                     vscode.window.showErrorMessage("Error converting to PDF, "+reason.toString());
                 })

--- a/src/commands/openDocumentLink.ts
+++ b/src/commands/openDocumentLink.ts
@@ -46,12 +46,13 @@ export class OpenDocumentLinkCommand implements Command {
 
 	private async tryOpen(path: string, args: OpenDocumentLinkArgs) {
 		const resource = vscode.Uri.file(path);
-		if (vscode.window.activeTextEditor && isAsciidocFile(vscode.window.activeTextEditor.document) && vscode.window.activeTextEditor.document.uri.fsPath === resource.fsPath) {
+    if (vscode.window.activeTextEditor && isAsciidocFile(vscode.window.activeTextEditor.document)
+        && vscode.window.activeTextEditor.document.uri.fsPath === resource.fsPath) {
 			return this.tryRevealLine(vscode.window.activeTextEditor, args.fragment);
 		} else {
 			return vscode.workspace.openTextDocument(resource)
 				.then(vscode.window.showTextDocument)
-				.then(editor => this.tryRevealLine(editor, args.fragment));
+				.then((editor) => this.tryRevealLine(editor, args.fragment));
 		}
 	}
 

--- a/src/commands/saveDocbook.ts
+++ b/src/commands/saveDocbook.ts
@@ -41,7 +41,7 @@ export class SaveDocbook implements Command {
                 return
             }
             vscode.window.showInformationMessage('Successfully converted to ', fsPath)
-                .then(selection => {
+                .then((selection) => {
                     if (selection === fsPath) {
                         switch (process.platform)
                         {

--- a/src/commands/saveHTML.ts
+++ b/src/commands/saveHTML.ts
@@ -38,7 +38,7 @@ export class SaveHTML implements Command {
                 return
             }
             vscode.window.showInformationMessage('Successfully converted to ', htmlPath)
-                .then(selection => {
+                .then((selection) => {
                     if (selection === htmlPath) {
                         switch (process.platform)
                         {

--- a/src/commands/showSource.ts
+++ b/src/commands/showSource.ts
@@ -16,7 +16,7 @@ export class ShowSourceCommand implements Command {
 	public execute() {
 		if (this.previewManager.activePreviewResource) {
 			return vscode.workspace.openTextDocument(this.previewManager.activePreviewResource)
-				.then(document => vscode.window.showTextDocument(document));
+				.then((document) => vscode.window.showTextDocument(document));
 		}
 		return undefined;
 	}

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -28,7 +28,7 @@ export default class AdocDocumentSymbolProvider implements vscode.DocumentSymbol
 
 	public async provideDocumentSymbolInformation(document: SkinnyTextDocument): Promise<vscode.SymbolInformation[]> {
 		const toc = await new TableOfContentsProvider(this.engine, document).getToc();
-		return toc.map(entry => this.toSymbolInformation(entry));
+		return toc.map((entry) => this.toSymbolInformation(entry));
 	}
 
 	public async provideDocumentSymbols(document: SkinnyTextDocument): Promise<vscode.DocumentSymbol[]> {

--- a/src/features/foldingProvider.ts
+++ b/src/features/foldingProvider.ts
@@ -25,11 +25,11 @@ export default class AsciidocFoldingProvider implements vscode.FoldingRangeProvi
 
 		const tokens = await this.engine.parse(document.uri, document.getText());
 		const regionMarkers = tokens.filter(isRegionMarker)
-			.map(token => ({ line: token.map[0], isStart: isStartRegion(token.content) }));
+			.map((token) => ({ line: token.map[0], isStart: isStartRegion(token.content) }));
 
 		const nestingStack: { line: number, isStart: boolean }[] = [];
 		return regionMarkers
-			.map(marker => {
+			.map((marker) => {
 				if (marker.isStart) {
 					nestingStack.push(marker);
 				} else if (nestingStack.length && nestingStack[nestingStack.length - 1].isStart) {
@@ -57,7 +57,7 @@ export default class AsciidocFoldingProvider implements vscode.FoldingRangeProvi
 	private async getHeaderFoldingRanges(document: vscode.TextDocument) {
 		const tocProvider = new TableOfContentsProvider(this.engine, document);
 		const toc = await tocProvider.getToc();
-		return toc.map(entry => {
+		return toc.map((entry) => {
 			let endLine = entry.location.range.end.line;
 			if (document.lineAt(endLine).isEmptyOrWhitespace && endLine >= entry.line + 1) {
 				endLine = endLine - 1;
@@ -84,7 +84,7 @@ export default class AsciidocFoldingProvider implements vscode.FoldingRangeProvi
 
 		const tokens = await this.engine.parse(document.uri, document.getText());
 		const multiLineListItems = tokens.filter(isFoldableToken);
-		return multiLineListItems.map(listItem => {
+		return multiLineListItems.map((listItem) => {
 			const start = listItem.map[0];
 			let end = listItem.map[1] - 1;
 			if (document.lineAt(end).isEmptyOrWhitespace && end >= start + 1) {

--- a/src/features/preview.ts
+++ b/src/features/preview.ts
@@ -114,11 +114,11 @@ export class AsciidocPreview {
 			this.dispose();
 		}, null, this.disposables);
 
-		this.editor.onDidChangeViewState(e => {
+		this.editor.onDidChangeViewState((e) => {
 			this._onDidChangeViewStateEmitter.fire(e);
 		}, null, this.disposables);
 
-		this.editor.webview.onDidReceiveMessage(e => {
+		this.editor.webview.onDidReceiveMessage((e) => {
 			if (e.source !== this._resource.toString()) {
 				return;
 			}
@@ -150,19 +150,19 @@ export class AsciidocPreview {
 			}
 		}, null, this.disposables);
 
-		vscode.workspace.onDidChangeTextDocument(event => {
+		vscode.workspace.onDidChangeTextDocument((event) => {
 			if (this.isPreviewOf(event.document.uri)) {
 				this.refresh();
 			}
 		}, null, this.disposables);
 
-		topmostLineMonitor.onDidChangeTopmostLine(event => {
+		topmostLineMonitor.onDidChangeTopmostLine((event) => {
 			if (this.isPreviewOf(event.resource)) {
 				this.updateForView(event.resource, event.line);
 			}
 		}, null, this.disposables);
 
-		vscode.window.onDidChangeTextEditorSelection(event => {
+		vscode.window.onDidChangeTextEditorSelection((event) => {
 			if (this.isPreviewOf(event.textEditor.document.uri)) {
 				this.postMessage({
 					type: 'onDidChangeTextEditorSelection',
@@ -172,7 +172,7 @@ export class AsciidocPreview {
 			}
 		}, null, this.disposables);
 
-		vscode.window.onDidChangeActiveTextEditor(editor => {
+		vscode.window.onDidChangeActiveTextEditor((editor) => {
 			if (editor && isAsciidocFile(editor.document) && !this._locked) {
 				this.update(editor.document.uri);
 			}
@@ -337,7 +337,9 @@ export class AsciidocPreview {
 		this.throttleTimer = undefined;
 
 		const document = await vscode.workspace.openTextDocument(resource);
-		if (!this.forceUpdate && this.currentVersion && this.currentVersion.resource.fsPath === resource.fsPath && this.currentVersion.version === document.version) {
+    if (!this.forceUpdate && this.currentVersion
+        && this.currentVersion.resource.fsPath === resource.fsPath
+        && this.currentVersion.version === document.version) {
 			if (this.line) {
 				this.updateForView(resource, this.line);
 			}

--- a/src/features/previewContentProvider.ts
+++ b/src/features/previewContentProvider.ts
@@ -132,7 +132,7 @@ export class AsciidocContentProvider {
 
 	private computeCustomStyleSheetIncludes(resource: vscode.Uri, config: AsciidocPreviewConfiguration): string {
 		if (Array.isArray(config.styles)) {
-			return config.styles.map(style => {
+			return config.styles.map((style) => {
 				return `<link rel="stylesheet" class="code-user-style" data-source="${style.replace(/"/g, '&quot;')}" href="${this.fixHref(resource, style)}" type="text/css" media="screen">`;
 			}).join('\n');
 		}
@@ -169,11 +169,11 @@ export class AsciidocContentProvider {
 		var baseStyles;
 		if (useEditorStyle) {
 			baseStyles = this.contributions.previewStylesEditor
-				.map(resource => `<link rel="stylesheet" type="text/css" href="${resource.toString()}">`)
+				.map((resource) => `<link rel="stylesheet" type="text/css" href="${resource.toString()}">`)
 				.join('\n');
 		} else {
 			baseStyles = this.contributions.previewStylesDefault
-				.map(resource => `<link rel="stylesheet" type="text/css" href="${resource.toString()}">`)
+				.map((resource) => `<link rel="stylesheet" type="text/css" href="${resource.toString()}">`)
 				.join('\n');
 		}
 

--- a/src/features/previewManager.ts
+++ b/src/features/previewManager.ts
@@ -98,7 +98,7 @@ export class AsciidocPreviewManager implements vscode.WebviewPanelSerializer {
 		resource: vscode.Uri,
 		previewSettings: PreviewSettings
 	): AsciidocPreview | undefined {
-		return this._previews.find(preview =>
+		return this._previews.find((preview) =>
 			preview.matchesResource(resource, previewSettings.previewColumn, previewSettings.locked));
 	}
 
@@ -140,7 +140,7 @@ export class AsciidocPreviewManager implements vscode.WebviewPanelSerializer {
 		});
 
 		preview.onDidChangeViewState(({ webviewPanel }) => {
-			disposeAll(this._previews.filter(otherPreview => preview !== otherPreview && preview!.matches(otherPreview)));
+			disposeAll(this._previews.filter((otherPreview) => preview !== otherPreview && preview!.matches(otherPreview)));
 			this.setPreviewActiveContext(webviewPanel.active);
 			this._activePreview = webviewPanel.active ? preview : undefined;
 		});

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -39,8 +39,8 @@ class VSCodeWorkspaceAsciidocDocumentProvider implements WorkspaceAsciidocDocume
 
 	async getAllAsciidocDocuments() {
 		const resources = await vscode.workspace.findFiles('**/*.md', '**/node_modules/**');
-		const docs = await Promise.all(resources.map(doc => this.getAsciidocDocument(doc)));
-		return docs.filter(doc => !!doc) as SkinnyTextDocument[];
+		const docs = await Promise.all(resources.map((doc) => this.getAsciidocDocument(doc)));
+		return docs.filter((doc) => !!doc) as SkinnyTextDocument[];
 	}
 
 	public get onDidChangeAsciidocDocument() {
@@ -65,25 +65,25 @@ class VSCodeWorkspaceAsciidocDocumentProvider implements WorkspaceAsciidocDocume
 
 		this._watcher = vscode.workspace.createFileSystemWatcher('**/*.md');
 
-		this._watcher.onDidChange(async resource => {
+		this._watcher.onDidChange(async (resource) => {
 			const document = await this.getAsciidocDocument(resource);
 			if (document) {
 				this._onDidChangeAsciidocDocumentEmitter.fire(document);
 			}
 		}, null, this._disposables);
 
-		this._watcher.onDidCreate(async resource => {
+		this._watcher.onDidCreate(async (resource) => {
 			const document = await this.getAsciidocDocument(resource);
 			if (document) {
 				this._onDidCreateAsciidocDocumentEmitter.fire(document);
 			}
 		}, null, this._disposables);
 
-		this._watcher.onDidDelete(async resource => {
+		this._watcher.onDidDelete(async (resource) => {
 			this._onDidDeleteAsciidocDocumentEmitter.fire(resource);
 		}, null, this._disposables);
 
-		vscode.workspace.onDidChangeTextDocument(e => {
+		vscode.workspace.onDidChangeTextDocument((e) => {
 			if (isAsciidocFile(e.document)) {
 				this._onDidChangeAsciidocDocumentEmitter.fire(e.document);
 			}
@@ -117,9 +117,9 @@ export default class AsciidocWorkspaceSymbolProvider implements vscode.Workspace
 			this._workspaceAsciidocDocumentProvider.onDidDeleteAsciidocDocument(this.onDidDeleteDocument, this, this._disposables);
 		}
 
-		const allSymbolsSets = await Promise.all(Array.from(this._symbolCache.values()).map(x => x.value));
+		const allSymbolsSets = await Promise.all(Array.from(this._symbolCache.values()).map((x) => x.value));
 		const allSymbols: vscode.SymbolInformation[] = Array.prototype.concat.apply([], allSymbolsSets);
-		return allSymbols.filter(symbolInformation => symbolInformation.name.toLowerCase().indexOf(query.toLowerCase()) !== -1);
+		return allSymbols.filter((symbolInformation) => symbolInformation.name.toLowerCase().indexOf(query.toLowerCase()) !== -1);
 	}
 
 	public async populateSymbolCache(): Promise<void> {

--- a/src/tableOfContentsProvider.ts
+++ b/src/tableOfContentsProvider.ts
@@ -43,7 +43,7 @@ export class TableOfContentsProvider {
 	public async lookup(fragment: string): Promise<TocEntry | undefined> {
 		const toc = await this.getToc();
 		const slug = githubSlugifier.fromHeading(fragment);
-		return toc.find(entry => entry.slug.equals(slug));
+		return toc.find((entry) => entry.slug.equals(slug));
 	}
 
 	private async buildToc(document: SkinnyTextDocument): Promise<TocEntry[]> {

--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -48,7 +48,7 @@ export class AsciidocParser {
     }
 
     private async convert_using_javascript(text: string, forHTMLSave: boolean, backend: string) {
-        return new Promise<string>(resolve => {
+        return new Promise<string>((resolve) => {
             const editor = vscode.window.activeTextEditor;
             const doc = editor.document;
             const documentPath = path.dirname(path.resolve(doc.fileName));
@@ -87,7 +87,7 @@ export class AsciidocParser {
                 // attributes = { 'copycss': true, 'stylesdir': this.stylesdir, 'stylesheet': 'asciidoctor-default.css@' }
             }
 
-            Object.keys(preview_attributes).forEach(key => {
+            Object.keys(preview_attributes).forEach((key) => {
                 if (typeof preview_attributes[key] === "string") {
                     attributes[key] = preview_attributes[key];
                 }
@@ -136,7 +136,7 @@ export class AsciidocParser {
         const preview_style = vscode.workspace.getConfiguration('asciidoc', null).get('preview.style', "");
         this.document = null;
 
-        return new Promise<string>(resolve => {
+        return new Promise<string>((resolve) => {
             let asciidoctor_command = vscode.workspace.getConfiguration('asciidoc', null).get('asciidoctor_command', 'asciidoctor');
             var RUBYOPT = process.env['RUBYOPT']
             if (RUBYOPT) {
@@ -185,7 +185,7 @@ export class AsciidocParser {
 
             adoc_cmd_args.push.apply(adoc_cmd_args, ['-b', backend])
 
-            Object.keys(preview_attributes).forEach(key => {
+            Object.keys(preview_attributes).forEach((key) => {
                 if (typeof preview_attributes[key] === "string") {
                     var value: string = preview_attributes[key]
 

--- a/src/util/links.ts
+++ b/src/util/links.ts
@@ -9,7 +9,7 @@ const knownSchemes = ['http:', 'https:', 'file:', 'mailto:'];
 export function getUriForLinkWithKnownExternalScheme(
 	link: string,
 ): vscode.Uri | undefined {
-	if (knownSchemes.some(knownScheme => link.toLowerCase().startsWith(knownScheme))) {
+	if (knownSchemes.some((knownScheme) => link.toLowerCase().startsWith(knownScheme))) {
 		return vscode.Uri.parse(link);
 	}
 

--- a/src/util/topmostLineMonitor.ts
+++ b/src/util/topmostLineMonitor.ts
@@ -14,7 +14,7 @@ export class AsciidocFileTopmostLineMonitor {
 	private readonly throttle = 50;
 
 	constructor() {
-		vscode.window.onDidChangeTextEditorVisibleRanges(event => {
+		vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
 			if (isAsciidocFile(event.textEditor.document)) {
 				const line = getVisibleLine(event.textEditor);
 				if (typeof line === 'number') {


### PR DESCRIPTION
ref #290

This adds a basic eslint setup, which can be extended in follow up PRs. Suggest first landing the tooling, then additional pull requests for adding more rules.

* removes `tslint` from package.json
* add tooling regarding typescript and eslint to package.json
* very basic eslint configuration
* code fixes for eslint rule `arrow-parens`