### PR TITLE
Correct resolution of paths with webpack bundle

### DIFF
--- a/webpack.config.app.js
+++ b/webpack.config.app.js
@@ -22,9 +22,12 @@ module.exports = {
     'asciidoctor-opal-runtime': 'asciidoctor-opal-runtime',
     '@asciidoctor/core': '@asciidoctor/core',
     '@asciidoctor/docbook-converter': '@asciidoctor/docbook-converter',
-  },  
+  },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+  },
+  node: {
+    __dirname: false,
   },
   module: {
     rules: [


### PR DESCRIPTION
I noticed that pasting of images on my local build was not working correctly, almost certainly caused by #276. The extension reported the script was not found:

![image](https://user-images.githubusercontent.com/674783/83342097-2ce9ac00-a33f-11ea-945a-b662417b1045.png)

The relevant code has a line like this: `const scriptPath = path.join(__dirname, '../../res/linux.sh')` which becomes incorrect after webpack treatment if it is not specified in the webpack configuration.

The solution is as per the [node docs](https://webpack.js.org/configuration/node/#node__dirname).