### PR TITLE
Added the ability to use the workspace path as the base_dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -420,6 +420,11 @@
 						"%asciidoc.saveDocbook.docbookVersion.docbook5%",
 						"%asciidoc.saveDocbook.docbookVersion.docbook45%"
 					]
+				},
+				"asciidoc.useWorkspaceRoot": {
+					"type": "boolean",
+					"default": false,
+					"description": "%asciidoc.useWorkspaceRoot.desc%"
 				}
 			}
 		},

--- a/package.nls.json
+++ b/package.nls.json
@@ -42,5 +42,6 @@
 	"asciidoc.forceUnixStyleSeparator.desc": "Force set the file separator style to unix style. If set false, separator style will follow the system style.",
 	"asciidoc.preview.openAsciiDocLinks.desc": "How should clicking on links to AsciiDoc files be handled in the preview.",
 	"asciidoc.preview.openAsciiDocLinks.inEditor": "Try to open links in the editor",
-	"asciidoc.preview.openAsciiDocLinks.inPreview": "Try to open links in the the AsciiDoc preview"
+	"asciidoc.preview.openAsciiDocLinks.inPreview": "Try to open links in the the AsciiDoc preview",
+	"asciidoc.useWorkspaceRoot.desc": "When in a workspace, use the workspace root path as the base dir."
 }

--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -56,6 +56,12 @@ export class AsciidocParser {
         const use_editor_stylesheet = vscode.workspace.getConfiguration('asciidoc', null).get('preview.useEditorStyle', false);
         const preview_attributes = vscode.workspace.getConfiguration('asciidoc', null).get('preview.attributes', {});
         const preview_style = vscode.workspace.getConfiguration('asciidoc', null).get('preview.style', "");
+        const useWorkspaceAsBaseDir = vscode.workspace.getConfiguration('asciidoc', null).get('useWorkspaceRoot');
+        
+        let base_dir = documentPath;
+        if (useWorkspaceAsBaseDir && typeof vscode.workspace.rootPath !== 'undefined') {
+          base_dir = vscode.workspace.rootPath;
+        }
 
         var attributes = {};
 
@@ -103,7 +109,7 @@ export class AsciidocParser {
           attributes: attributes,
           header_footer: true,
           to_file: false,
-          base_dir: documentPath,
+          base_dir: base_dir,
           sourcemap: true,
           backend: backend,
         }
@@ -133,7 +139,13 @@ export class AsciidocParser {
       const use_editor_stylesheet = vscode.workspace.getConfiguration('asciidoc', null).get('preview.useEditorStyle', false);
       const preview_attributes = vscode.workspace.getConfiguration('asciidoc', null).get('preview.attributes', {});
       const preview_style = vscode.workspace.getConfiguration('asciidoc', null).get('preview.style', "");
+      const useWorkspaceAsBaseDir = vscode.workspace.getConfiguration('asciidoc', null).get('useWorkspaceRoot');
       this.document = null;
+
+      let base_dir = documentPath;
+      if (useWorkspaceAsBaseDir && typeof vscode.workspace.rootPath !== 'undefined') {
+        base_dir = vscode.workspace.rootPath.replace('"', '\\"');
+      }
 
       return new Promise<string>((resolve) => {
         let asciidoctor_command = vscode.workspace.getConfiguration('asciidoc', null).get('asciidoctor_command', 'asciidoctor');
@@ -198,7 +210,7 @@ export class AsciidocParser {
 
         adoc_cmd_args.push.apply(adoc_cmd_args, ['-a', 'env-vscode'])
 
-        adoc_cmd_args.push.apply(adoc_cmd_args, ['-q', '-B', '"' + documentPath + '"', '-o', '-', '-'])
+        adoc_cmd_args.push.apply(adoc_cmd_args, ['-q', '-B', '"' + base_dir + '"', '-o', '-', '-'])
         var asciidoctor = spawn(adoc_cmd, adoc_cmd_args, options);
 
         asciidoctor.stderr.on('data', (data) => {


### PR DESCRIPTION
This PR adds a configuration option that allows to use the workspace path (when using a workspace) as the asciidoctor base_dir.
This option will be very useful when having a multi-directory documentation project, that includes files from a common directory. For example:
```
project/
├── common
│   └── settings.adoc
├── data
│   └── file1.adoc
└── index.adoc
```
Where file1.adoc uses: `include::{docdir}/common/settings.adoc[]`.
Previewing file1.adoc would display an `Unresolved directive in <stdin> - include::{docdir}/common/settings.adoc[]` message.