### PR TITLE
Fix unexpected splitting multibyte chars while chunking

### DIFF
--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -276,14 +276,14 @@ export class AsciidocParser {
           errorMessage += "Go to `File -> Preferences -> User settings` and adjust the asciidoc.asciidoctor_command</b>"
           resolve(errorMessage);
         })
-        var result_data = ''
+        var result_data = new Buffer('');
         /* with large outputs we can receive multiple calls */
         asciidoctor.stdout.on('data', (data) => {
-          result_data += data.toString();
+          result_data = Buffer.concat([result_data, data as Buffer]);
         });
         asciidoctor.on('close', (code) => {
-          //var result = this.fixLinks(result_data);
-          resolve(result_data);
+          //var result = this.fixLinks(result_data.toString());
+          resolve(result_data.toString());
         })
         asciidoctor.stdin.write(text);
         asciidoctor.stdin.end();


### PR DESCRIPTION
when "save HTML document" command executed, it often happens a multibyte character is unexpectedly split by Stream chunking like the following.

```javascript
{ data: '...コンピュータプログラムの明�' }
{ data: '��化を目的にし...' }
```

refs: https://nodejs.org/api/child_process.html#child_process_maxbuffer_and_unicode

it can be the solution to replace string concatenation with Buffer's one and convert to string when the stream closed.
