### PR TITLE
Enable use of ${workspaceFolder} in preview.attributes

### DIFF
--- a/src/text-parser.ts
+++ b/src/text-parser.ts
@@ -86,7 +86,10 @@ export class AsciidocParser {
 
         Object.keys(preview_attributes).forEach((key) => {
           if (typeof preview_attributes[key] === "string") {
-            attributes[key] = preview_attributes[key];
+            attributes[key] = preview_attributes[key]
+            if(workspacePath !== undefined) {
+              attributes[key] = attributes[key].replace("${workspaceFolder}", workspacePath[0].uri.path);
+            }
           }
         })
 
@@ -251,6 +254,9 @@ export class AsciidocParser {
         Object.keys(preview_attributes).forEach((key) => {
           if (typeof preview_attributes[key] === "string") {
             var value: string = preview_attributes[key]
+            if(workspacePath !== undefined) {
+              value = value.replace("${workspaceFolder}", workspacePath[0].uri.path);
+            }
 
             if (value.endsWith('!')) {
               adoc_cmd_args.push.apply(adoc_cmd_args, ['-a', `${value}`])


### PR DESCRIPTION
This allows users to define attributes in settings.json relative to ${workspaceFolder}.
It enables for example to define "kroki-plantuml-include" : "${workspaceFolder}/style.pu"
(a path relative to the workspaceFolder), while keeping useWorkspaceRoot = false.

Setting asciidoc.useWorkspaceRoot = true is not flexible enough for many use cases 
as this changes general behaviour a lot , which is not always desired:
e.g. include::myFile.adoc[] changes from "relative to the document" to "relative to workspaceFolder".