### PR TITLE
Fixed first-development missing JS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "npm: compile"
+			"preLaunchTask": "adoc-prelaunch"
 		},
 		{
 			"name": "Extension Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,13 @@
             "-p", "tsconfig.json"
         ],
         "dependsOn": "npm: webpack-preview-dev"
+      },
+      {
+          "label": "adoc-prelaunch",
+          "dependsOn": [
+              "npm: webpack",
+              "npm: compile"
+          ]
       }
     ]
   }


### PR DESCRIPTION
Changed launch task dependency so it runs `webpack` prior to launching debug window. 

Previous behavior: `dist/index.js` and `dist/pre.js` were not compiled and included, and preview window in extension development host fail to load the scripts.

Current behavior: `webpack` is run before compiling, generating the required scripts.