### PR TITLE
Adds syntax and autocomplete for asciidoctor-bibtex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@asciidoctor/core": "2.1.0",
 				"@asciidoctor/docbook-converter": "^2.0.0",
+				"@orcid/bibtex-parse-js": "^0.0.25",
 				"@types/vscode": "^1.31.0",
 				"asciidoctor-kroki": "^0.12.0",
 				"file-url": "^3.0.0",
@@ -92,6 +93,11 @@
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
+		},
+		"node_modules/@orcid/bibtex-parse-js": {
+			"version": "0.0.25",
+			"resolved": "https://registry.npmjs.org/@orcid/bibtex-parse-js/-/bibtex-parse-js-0.0.25.tgz",
+			"integrity": "sha512-n6VuG5/WjiifC1DoUzq0sUCWNSbAyRZznBgvPcY4jVZ/2eJiMv2tNUAt2NukbnFExOUa0RyTOFsqhH2MGpiLgQ=="
 		},
 		"node_modules/@types/color-name": {
 			"version": "1.1.1",
@@ -1873,18 +1879,18 @@
 			}
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"dev": true,
 			"dependencies": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
 				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
@@ -5830,9 +5836,9 @@
 			"dev": true
 		},
 		"node_modules/ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
 			"dev": true,
 			"dependencies": {
 				"figgy-pudding": "^3.5.1"
@@ -6734,10 +6740,8 @@
 			"integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
 			"dev": true,
 			"dependencies": {
-				"chokidar": "^3.4.0",
 				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.0"
+				"neo-async": "^2.5.0"
 			},
 			"optionalDependencies": {
 				"chokidar": "^3.4.0",
@@ -7209,9 +7213,9 @@
 			}
 		},
 		"node_modules/y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"node_modules/yallist": {
@@ -7395,6 +7399,11 @@
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
+		},
+		"@orcid/bibtex-parse-js": {
+			"version": "0.0.25",
+			"resolved": "https://registry.npmjs.org/@orcid/bibtex-parse-js/-/bibtex-parse-js-0.0.25.tgz",
+			"integrity": "sha512-n6VuG5/WjiifC1DoUzq0sUCWNSbAyRZznBgvPcY4jVZ/2eJiMv2tNUAt2NukbnFExOUa0RyTOFsqhH2MGpiLgQ=="
 		},
 		"@types/color-name": {
 			"version": "1.1.1",
@@ -8995,9 +9004,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.12.0",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"version": "4.11.9",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
 					"dev": true
 				}
 			}
@@ -12327,9 +12336,9 @@
 			"dev": true
 		},
 		"ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
 			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1"
@@ -13533,9 +13542,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yallist": {

--- a/package.json
+++ b/package.json
@@ -489,6 +489,7 @@
 	"dependencies": {
 		"@asciidoctor/core": "2.1.0",
 		"@asciidoctor/docbook-converter": "^2.0.0",
+		"@orcid/bibtex-parse-js": "^0.0.25",
 		"@types/vscode": "^1.31.0",
 		"asciidoctor-kroki": "^0.12.0",
 		"file-url": "^3.0.0",

--- a/src/providers/bibtex.provider.ts
+++ b/src/providers/bibtex.provider.ts
@@ -1,0 +1,53 @@
+import * as vscode from "vscode";
+import { createContext, Context } from "./createContext";
+import { readdirSync, readFileSync } from "fs";
+const bibtexParse = require("@orcid/bibtex-parse-js");
+
+export const BibtexProvider = {
+  provideCompletionItems,
+};
+
+export async function provideCompletionItems(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): Promise<vscode.CompletionItem[]> {
+  const context = createContext(document, position);
+
+  return shouldProvide(context) ? provide(context) : Promise.resolve([]);
+}
+
+/**
+ * Checks if we should provide any CompletionItems
+ * @param context
+ */
+function shouldProvide(context: Context): boolean {
+  return /(citenp\:)\S*/gi.test(context.textFullLine);
+}
+
+function getCitationKeys(): string[] {
+  const files = readdirSync(".").filter((fn) => fn.endsWith(".bib"));
+  const filesContent = files.map((file) =>
+    readFileSync(file).toString("utf-8")
+  );
+  const bibtexJson = filesContent.map((content) => bibtexParse.toJSON(content));
+  const flatMap = (f, xs) => xs.reduce((r, x) => r.concat(f(x)), []);
+  return flatMap(
+    (jsons) => jsons.map((entries) => entries.citationKey),
+    bibtexJson
+  );
+}
+
+/**
+ * Provide Completion Items
+ */
+async function provide(context: Context): Promise<vscode.CompletionItem[]> {
+  const bibtexSearch = context.textFullLine.replace("citenp:", "");
+  const citationKeys = getCitationKeys();
+
+  return citationKeys
+    .filter((citationKeys) => citationKeys.match(bibtexSearch))
+    .map((citationKey) => ({
+      label: `[${citationKey}]`,
+      kind: vscode.CompletionItemKind.Reference,
+    }));
+}

--- a/src/providers/bibtex.provider.ts
+++ b/src/providers/bibtex.provider.ts
@@ -21,7 +21,13 @@ export async function provideCompletionItems(
  * @param context
  */
 function shouldProvide(context: Context): boolean {
-  return /(citenp\:)\S*/gi.test(context.textFullLine);
+  const keyword = "citenp:";
+  // Check if cursor is after citenp:
+  const occurence = context.textFullLine.indexOf(
+    keyword,
+    context.position.character - keyword.length
+  );
+  return occurence === context.position.character - keyword.length;
 }
 
 async function getCitationKeys(): Promise<string[]> {
@@ -41,7 +47,15 @@ async function getCitationKeys(): Promise<string[]> {
  * Provide Completion Items
  */
 async function provide(context: Context): Promise<vscode.CompletionItem[]> {
-  const bibtexSearch = context.textFullLine.replace("citenp:", "");
+  const { textFullLine, position } = context;
+  const indexOfNextWhiteSpace = textFullLine.includes(" ", position.character)
+    ? textFullLine.indexOf(" ", position.character)
+    : textFullLine.length;
+  //Find the text between citenp: and the next whitespace character
+  const bibtexSearch = textFullLine.substring(
+    textFullLine.lastIndexOf(":", position.character + 1) + 1,
+    indexOfNextWhiteSpace
+  );
   const citationKeys = await getCitationKeys();
 
   return citationKeys

--- a/src/providers/bibtex.provider.ts
+++ b/src/providers/bibtex.provider.ts
@@ -24,10 +24,10 @@ function shouldProvide(context: Context): boolean {
   return /(citenp\:)\S*/gi.test(context.textFullLine);
 }
 
-function getCitationKeys(): string[] {
-  const files = readdirSync(".").filter((fn) => fn.endsWith(".bib"));
+async function getCitationKeys(): Promise<string[]> {
+  const files = await vscode.workspace.findFiles("*.bib");
   const filesContent = files.map((file) =>
-    readFileSync(file).toString("utf-8")
+    readFileSync(file.path).toString("utf-8")
   );
   const bibtexJson = filesContent.map((content) => bibtexParse.toJSON(content));
   const flatMap = (f, xs) => xs.reduce((r, x) => r.concat(f(x)), []);
@@ -42,7 +42,7 @@ function getCitationKeys(): string[] {
  */
 async function provide(context: Context): Promise<vscode.CompletionItem[]> {
   const bibtexSearch = context.textFullLine.replace("citenp:", "");
-  const citationKeys = getCitationKeys();
+  const citationKeys = await getCitationKeys();
 
   return citationKeys
     .filter((citationKeys) => citationKeys.match(bibtexSearch))

--- a/src/providers/createContext.ts
+++ b/src/providers/createContext.ts
@@ -4,6 +4,7 @@ export interface Context {
   textFullLine: string;
   document: vscode.TextDocument;
   documentExtension: string | undefined;
+  position: vscode.Position;
 }
 
 export function createContext(
@@ -16,6 +17,7 @@ export function createContext(
     textFullLine,
     document,
     documentExtension,
+    position,
   };
 }
 

--- a/src/util/includeAutoCompletion.ts
+++ b/src/util/includeAutoCompletion.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { AsciidocProvider } from '../providers/asciidoc.provider';
+import { BibtexProvider } from "../providers/bibtex.provider";
 import { disposeAll } from '../util/dispose';
 
 export class AsciidocFileIncludeAutoCompletionMonitor {
@@ -16,7 +17,17 @@ export class AsciidocFileIncludeAutoCompletionMonitor {
       ...[":", "/"]
     );
 
+    const bibtexDisposable = vscode.languages.registerCompletionItemProvider(
+      {
+        language: "asciidoc",
+        scheme: "file",
+      },
+      BibtexProvider,
+      ...[":", "/"]
+    );
+
     this.disposables.push(disposable);
+    this.disposables.push(bibtexDisposable);
 	}
 
 	dispose() {

--- a/syntaxes/Asciidoctor.json
+++ b/syntaxes/Asciidoctor.json
@@ -206,6 +206,9 @@
           "include": "#characters"
         },
         {
+          "include": "#bibtex-macro"
+        },
+        {
           "include": "#bibliography-anchor"
         }
       ]
@@ -1167,6 +1170,24 @@
         {
           "name": "markup.macro.inline.stem.asciidoc",
           "begin": "(?<!\\\\)(stem|(?:latex|ascii)math):([a-z,]*)(\\[)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.asciidoc"
+            },
+            "2": {
+              "name": "markup.meta.attribute-list.asciidoc"
+            }
+          },
+          "contentName": "string.unquoted.asciidoc",
+          "end": "\\]|^$"
+        }
+      ]
+    },
+    "bibtex-macro": {
+      "patterns": [
+        {
+          "name": "markup.macro.inline.bibtex.asciidoc",
+          "begin": "(?<!\\\\)(citenp:)([a-z,]*)(\\[)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.function.asciidoc"


### PR DESCRIPTION
First of all thanks for the plugin, I'm writing my master thesis in asciidoc and it's amazing!

We use asciidoctor-bibtex to handle citations in our paper, and we found it annoying that it does not autosuggest citationkeys while we are writing. So I decided to write it myself :) 

The syntax for asciidoctor-bibtex is `citenp:[citationKey] `. This is added in syntax.json
The autocomplete searches for .bib-files in the project directory and parses these with `bibtex-parser-js`.
Works inline.

![2021-04-29 14 50 11](https://user-images.githubusercontent.com/26060323/116553324-4b16ae00-a8fa-11eb-8d1e-65797006b47d.gif)


The plugin works with this repo if you want to try it yourself
https://github.com/aslakhol/thesis


If this is something you want in your plugin, I'm happy to fix any suggestions or feedback you have.  
