### PR TITLE
Parse file URI correctly for DiagnosticCollection handling on Windows…

### DIFF
--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -189,7 +189,7 @@ export class AsciidocParser {
             diagnostics.push(diagnosticError)
           })
           if (this.errorCollection) {
-            this.errorCollection.set(vscode.Uri.parse(doc.fileName), diagnostics)
+            this.errorCollection.set(doc.uri, diagnostics)
           }
         }
         resolve(resultHTML)


### PR DESCRIPTION
Closes #466

The previous method appears to damage the path on Windows and is not as per the example extension:
https://github.com/microsoft/vscode-extension-samples/blob/main/code-actions-sample/src/diagnostics.ts