### PR TITLE
Part of #425, fix base directory references

### DIFF
--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -119,7 +119,7 @@ export class AsciidocParser {
         attributes: attributes,
         header_footer: true,
         to_file: false,
-        baseDir: baseDir,
+        base_dir: baseDir,
         sourcemap: true,
         backend: backend,
         extension_registry: registry,


### PR DESCRIPTION
We recently broken the base directory calling of the processor. I thought it was in e8612434 but that seems to have been just copying across the previous error.

This PR corrects the base directory to match the docs and fixes includes and very likely other things.

https://docs.asciidoctor.org/asciidoctor.js/latest/processor/convert-options/
