### PR TITLE
Prepare CHANGELOG for 2.8.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Ensure Asciidoctor.js error reporting is displayed on Windows (closes #466)
 - Provide offline and integrated code syntax highlighting with highlight.js (closes #459)
+- Update preview on preferences change (closes #447) 
 - Enforce code style (closes #446)
 - Make `use_kroki` setting change effective without VS code restart (closes #444)
 - Allow links to work in the preview pane (closes #435)


### PR DESCRIPTION
This should be merged after #463 and just updates the CHANGELOG.
I think there's enough here for a release.
The enforcing of code style resulted in a number of changes and there be may be end-user functionality breakages (I am especially glad I caught my error in #465) but I expect to be available to look into this if it becomes a problem.