### PR TITLE
Scroll to the first line when the preview hits top

### DIFF
--- a/preview-src/index.ts
+++ b/preview-src/index.ts
@@ -6,7 +6,7 @@ import { ActiveLineMarker } from './activeLineMarker'
 import { onceDocumentLoaded } from './events'
 import { createPosterForVsCode } from './messaging'
 import { getEditorLineNumberForPageOffset, scrollToRevealSourceLine } from './scroll-sync'
-import { getSettings, getData } from './settings'
+import { getData, getSettings } from './settings'
 import throttle = require('lodash.throttle');
 
 declare let acquireVsCodeApi: any
@@ -89,7 +89,6 @@ window.addEventListener('message', (event) => {
     return
   }
 
-  //console.log("GOT MESSAGE", event.data);
   switch (event.data.type) {
     case 'onDidChangeTextEditorSelection':
       marker.onDidChangeTextEditorSelection(event.data.line)
@@ -161,7 +160,10 @@ if (settings.scrollEditorWithPreview) {
       scrollDisabled = false
     } else {
       const line = getEditorLineNumberForPageOffset(window.scrollY)
-      if (typeof line === 'number' && !isNaN(line)) {
+      if (window.scrollY === 0) {
+        // scroll to top, document title does not have a data-line attribute
+        messaging.postMessage('revealLine', { line: 0 })
+      } else if (typeof line === 'number' && !isNaN(line)) {
         messaging.postMessage('revealLine', { line })
       }
     }

--- a/preview-src/scroll-sync.ts
+++ b/preview-src/scroll-sync.ts
@@ -96,11 +96,13 @@ export function scrollToRevealSourceLine (line: number) {
       // Between two elements. Go to percentage offset between them.
       const betweenProgress = (line - previous.line) / (next.line - previous.line)
       const elementOffset = next.element.getBoundingClientRect().top - previousTop
-      scrollTo = previousTop + betweenProgress * elementOffset
+      scrollTo = window.scrollY + previousTop + betweenProgress * elementOffset
+    } else if (line === 0) {
+      scrollTo = 0
     } else {
-      scrollTo = previousTop
+      scrollTo = window.scrollY + previousTop
     }
-    window.scroll(0, Math.max(1, window.scrollY + scrollTo))
+    window.scroll(0, Math.max(1, scrollTo))
   }
 }
 


### PR DESCRIPTION
Since the document title does not have a `data-line` attribute when we scroll to the top on the preview it does not scroll to the document title (but to the first block).

I didn't find a way to do the opposite (i.e., when we scroll to the top of the AsciiDoc document, scroll to the top of the preview). The reason is that we cannot tell what is on the first line. I guess we could read the first line and check if it's the document title but even then the document title could be hidden in the preview with `:showtitle!:`.

So this pull request partially fixes #348 