### PR TITLE
Add link provider for includes, closes #99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Initial work to make the extension available as a Web Extension (#473)
 - Scroll to the first line when the preview hits top (closes #348)
 - Removed a double word, add some colons for clarity, and puctuation in README.md (#483)
+- Support hyperlinks in source pane for include directive (#498)
 
 ## 2.8.10
 

--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -6,8 +6,7 @@ import * as vscode from 'vscode'
 import { AsciidocContributions } from './asciidocExtensions'
 import { Slugifier } from './slugify'
 import { AsciidocParser } from './asciidocParser'
-import { ExtensionContext } from "vscode";
-import { Asciidoctor } from "@asciidoctor/core";
+import { Asciidoctor } from '@asciidoctor/core'
 
 const FrontMatterRegex = /^---\s*[^]*?(-{3}|\.{3})\s*/
 
@@ -61,13 +60,13 @@ export class AsciidocEngine {
 
     this.firstLine = offset
     const textDocument = await vscode.workspace.openTextDocument(documentUri)
-    const {html: output, document} = await this.getEngine().parseText(text, textDocument, forHTML, backend, context, editor)
-    return {output, document}
+    const { html: output, document } = await this.getEngine().parseText(text, textDocument, forHTML, backend, context, editor)
+    return { output, document }
   }
 
   public async load (documentUri: vscode.Uri, source: string): Promise<any> {
     const textDocument = await vscode.workspace.openTextDocument(documentUri)
-    const {document} = await this.getEngine().parseText(source, textDocument)
+    const { document } = await this.getEngine().parseText(source, textDocument)
     return document
   }
 }

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import { spawn } from 'child_process'
 import { AsciidoctorWebViewConverter } from './asciidoctorWebViewConverter'
-import { Asciidoctor } from "@asciidoctor/core";
+import { Asciidoctor } from '@asciidoctor/core'
 
 const asciidoctorFindIncludeProcessor = require('./asciidoctorFindIncludeProcessor')
 
@@ -220,7 +220,7 @@ export class AsciidocParser {
             this.errorCollection.set(doc.uri, diagnostics)
           }
         }
-        resolve({html: resultHTML, document})
+        resolve({ html: resultHTML, document })
       } catch (e) {
         vscode.window.showErrorMessage(e.toString())
         reject(e)
@@ -350,6 +350,6 @@ export class AsciidocParser {
     }
 
     const html = await this.convertUsingApplication(text, doc, forHTMLSave, backend)
-    return {html}
+    return { html }
   }
 }

--- a/src/asciidoctorFindIncludeProcessor.ts
+++ b/src/asciidoctorFindIncludeProcessor.ts
@@ -1,0 +1,49 @@
+interface IncludeEntry {
+  name: string
+  position: number
+  length: string
+}
+
+interface IncludeItem {
+  [index: number]: IncludeEntry
+}
+
+interface IncludeItems extends Array<IncludeItem>{}
+
+let baseDocIncludes: IncludeItems[] = []
+
+function findIncludeProcessor () {
+  const self = this
+
+  self.handles(function (_target) {
+    return true
+  })
+
+  self.process(function (doc, reader, target, attrs) {
+    // We don't meaningfully process the includes, we just want to identify
+    // their line number and path if they belong in the base document
+    if (reader.path === '<stdin>') {
+      baseDocIncludes.push([target, reader.lineno - 1, target.length])
+    }
+    return reader.pushInclude(['nothing'], target, target, 1, attrs)
+  })
+}
+
+module.exports.getBaseDocIncludes = function getBaseDocIncludes () {
+  return baseDocIncludes
+}
+
+module.exports.resetIncludes = function resetIncludes () {
+  baseDocIncludes = []
+}
+
+module.exports.register = function register (registry) {
+  if (typeof registry.register === 'function') {
+    registry.register(function () {
+      this.includeProcessor(findIncludeProcessor)
+    })
+  } else if (typeof registry.block === 'function') {
+    registry.includeProcessor(findIncludeProcessor)
+  }
+  return registry
+}

--- a/src/asciidoctorFindIncludeProcessor.ts
+++ b/src/asciidoctorFindIncludeProcessor.ts
@@ -1,16 +1,14 @@
 interface IncludeEntry {
-  name: string
-  position: number
-  length: string
+  index: number,
+  name: string,
+  position: number,
+  length: string,
 }
 
-interface IncludeItem {
-  [index: number]: IncludeEntry
-}
+interface IncludeItems extends Array<IncludeEntry>{}
 
-interface IncludeItems extends Array<IncludeItem>{}
-
-let baseDocIncludes: IncludeItems[] = []
+let baseDocIncludes: IncludeItems = []
+let includeIndex = 0
 
 function findIncludeProcessor () {
   const self = this
@@ -23,7 +21,8 @@ function findIncludeProcessor () {
     // We don't meaningfully process the includes, we just want to identify
     // their line number and path if they belong in the base document
     if (reader.path === '<stdin>') {
-      baseDocIncludes.push([target, reader.lineno - 1, target.length])
+      baseDocIncludes.push({ index: includeIndex, name: target, position: reader.lineno - 1, length: target.length })
+      includeIndex += 1
     }
     return reader.pushInclude(['nothing'], target, target, 1, attrs)
   })
@@ -34,6 +33,7 @@ module.exports.getBaseDocIncludes = function getBaseDocIncludes () {
 }
 
 module.exports.resetIncludes = function resetIncludes () {
+  includeIndex = 0
   baseDocIncludes = []
 }
 

--- a/src/commands/exportAsPDF.ts
+++ b/src/commands/exportAsPDF.ts
@@ -82,15 +82,13 @@ export class ExportAsPDF implements Command {
         .getConfiguration('asciidoc')
         .get('wkHTMLtoPDFPath', '')
 
-      const parser = new AsciidocParser(path.resolve(doc.fileName))
-      const body = await this.engine.render(doc.uri, true, text, false, 'html5')
-      const html = body
-      const showTitlePage = parser.getAttribute('showTitlePage')
-      const author = parser.getAttribute('author')
-      const email = parser.getAttribute('email')
-      const doctitle: string | undefined = parser.getAttribute('doctitle')
-      const titlePageLogo: string | undefined = parser.getAttribute('titlePageLogo')
-      const footerCenter: string | undefined = parser.getAttribute('footer-center')
+      const {output: html, document} = await this.engine.render(doc.uri, true, text, false, 'html5')
+      const showTitlePage = document?.getAttribute('showTitlePage')
+      const author = document?.getAttribute('author')
+      const email = document?.getAttribute('email')
+      const doctitle: string | undefined = document?.getAttribute('doctitle')
+      const titlePageLogo: string | undefined = document?.getAttribute('titlePageLogo')
+      const footerCenter: string | undefined = document?.getAttribute('footer-center')
       let cover: string | undefined
       let imageHTML: string = ''
       if (!(showTitlePage === null)) {

--- a/src/commands/exportAsPDF.ts
+++ b/src/commands/exportAsPDF.ts
@@ -5,7 +5,6 @@ import * as path from 'path'
 import { exec, spawn } from 'child_process'
 import { uuidv4 } from 'uuid'
 import * as zlib from 'zlib'
-import { AsciidocParser } from '../asciidocParser'
 import { AsciidocEngine } from '../asciidocEngine'
 import { Command } from '../commandManager'
 
@@ -82,7 +81,7 @@ export class ExportAsPDF implements Command {
         .getConfiguration('asciidoc')
         .get('wkHTMLtoPDFPath', '')
 
-      const {output: html, document} = await this.engine.render(doc.uri, true, text, false, 'html5')
+      const { output: html, document } = await this.engine.render(doc.uri, true, text, false, 'html5')
       const showTitlePage = document?.getAttribute('showTitlePage')
       const author = document?.getAttribute('author')
       const email = document?.getAttribute('email')

--- a/src/commands/saveDocbook.ts
+++ b/src/commands/saveDocbook.ts
@@ -31,7 +31,7 @@ export class SaveDocbook implements Command {
     const config = vscode.workspace.getConfiguration('asciidoc', doc.uri)
     const docbookVersion = config.get<string>('saveDocbook.docbookVersion', 'docbook5')
 
-    const {output} = await this.engine.render(doc.uri, true, text, true, docbookVersion)
+    const { output } = await this.engine.render(doc.uri, true, text, true, docbookVersion)
 
     fs.writeFile(fsPath, output, function (err) {
       if (err) {

--- a/src/commands/saveDocbook.ts
+++ b/src/commands/saveDocbook.ts
@@ -31,7 +31,7 @@ export class SaveDocbook implements Command {
     const config = vscode.workspace.getConfiguration('asciidoc', doc.uri)
     const docbookVersion = config.get<string>('saveDocbook.docbookVersion', 'docbook5')
 
-    const output = await this.engine.render(doc.uri, true, text, true, docbookVersion)
+    const {output} = await this.engine.render(doc.uri, true, text, true, docbookVersion)
 
     fs.writeFile(fsPath, output, function (err) {
       if (err) {

--- a/src/commands/saveHTML.ts
+++ b/src/commands/saveHTML.ts
@@ -28,7 +28,7 @@ export class SaveHTML implements Command {
       htmlPath = path.join(docPath.dir, docPath.name + '.html')
     }
 
-    const {output: html} = await this.engine.render(doc.uri, true, text, true, 'html5')
+    const { output: html } = await this.engine.render(doc.uri, true, text, true, 'html5')
 
     fs.writeFile(htmlPath, html, function (err) {
       if (err) {

--- a/src/commands/saveHTML.ts
+++ b/src/commands/saveHTML.ts
@@ -28,7 +28,7 @@ export class SaveHTML implements Command {
       htmlPath = path.join(docPath.dir, docPath.name + '.html')
     }
 
-    const html = await this.engine.render(doc.uri, true, text, true, 'html5')
+    const {output: html} = await this.engine.render(doc.uri, true, text, true, 'html5')
 
     fs.writeFile(htmlPath, html, function (err) {
       if (err) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export function activate (context: vscode.ExtensionContext) {
   context.subscriptions.push(includeAutoCompletionMonitor)
 
   context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider))
-  context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()))
+  context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider(engine)))
   context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new AsciidocWorkspaceSymbolProvider(symbolProvider)))
   context.subscriptions.push(vscode.languages.registerCompletionItemProvider(selector, new AttributeCompleter(), '{'))
   const previewSecuritySelector = new PreviewSecuritySelector(cspArbiter, previewManager)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ export function activate (context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider))
   context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider(engine)))
   context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new AsciidocWorkspaceSymbolProvider(symbolProvider)))
-  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(selector, new AttributeCompleter(), '{'))
+  context.subscriptions.push(vscode.languages.registerCompletionItemProvider(selector, new AttributeCompleter(contributions.extensionUri), '{'))
   const previewSecuritySelector = new PreviewSecuritySelector(cspArbiter, previewManager)
 
   const commandManager = new CommandManager()

--- a/src/features/attributeCompleter.ts
+++ b/src/features/attributeCompleter.ts
@@ -3,12 +3,11 @@ import * as vscode from 'vscode'
 import { AsciidocParser } from '../asciidocParser'
 
 export class AttributeCompleter {
-
-  constructor(private readonly extensionUri: vscode.Uri) {
+  constructor (private readonly extensionUri: vscode.Uri) {
   }
 
   async provideCompletionItems (textDocument: vscode.TextDocument, _position: vscode.Position) {
-    const { html, document } = await new AsciidocParser(this.extensionUri).parseText(textDocument.getText(), textDocument)
+    const { document } = await new AsciidocParser(this.extensionUri).parseText(textDocument.getText(), textDocument)
     if (document) {
       const attributes = document.getAttributes()
       const attribs = []

--- a/src/features/attributeCompleter.ts
+++ b/src/features/attributeCompleter.ts
@@ -3,18 +3,23 @@ import * as vscode from 'vscode'
 import { AsciidocParser } from '../asciidocParser'
 
 export class AttributeCompleter {
-  provideCompletionItems (document: vscode.TextDocument, _position: vscode.Position) {
-    const adoc = new AsciidocParser(document.uri.fsPath)
-    adoc.parseText(document.getText(), document)
-    const attributes = adoc.document.getAttributes()
-    const attribs = []
 
-    for (const key in attributes) {
-      const attrib = new vscode.CompletionItem(key, vscode.CompletionItemKind.Variable)
-      attrib.detail = attributes[key].toString()
-      attribs.push(attrib)
+  constructor(private readonly extensionUri: vscode.Uri) {
+  }
+
+  async provideCompletionItems (textDocument: vscode.TextDocument, _position: vscode.Position) {
+    const { html, document } = await new AsciidocParser(this.extensionUri).parseText(textDocument.getText(), textDocument)
+    if (document) {
+      const attributes = document.getAttributes()
+      const attribs = []
+
+      for (const key in attributes) {
+        const attrib = new vscode.CompletionItem(key, vscode.CompletionItemKind.Variable)
+        attrib.detail = attributes[key].toString()
+        attribs.push(attrib)
+      }
+
+      return attribs
     }
-
-    return attribs
   }
 }

--- a/src/features/documentLinkProvider.ts
+++ b/src/features/documentLinkProvider.ts
@@ -4,8 +4,16 @@
 
 import * as path from 'path'
 import * as vscode from 'vscode'
+import * as nls from 'vscode-nls'
 import { OpenDocumentLinkCommand } from '../commands/openDocumentLink'
 import { getUriForLinkWithKnownExternalScheme } from '../util/links'
+import { similarArrayMatch } from '../similarArrayMatch'
+import { isSchemeBlacklisted } from '../linkSanitizer'
+
+const localize = nls.loadMessageBundle()
+export interface AsciidoctorLinkRegexes {
+  [key: string]: RegExp
+}
 
 function normalizeLink (
   document: vscode.TextDocument,
@@ -21,141 +29,78 @@ function normalizeLink (
   // Use a fake scheme to avoid parse warnings
   const tempUri = vscode.Uri.parse(`vscode-resource:${link}`)
 
-  let resourcePath = tempUri.path
+  let resourcePath
   if (!tempUri.path) {
     resourcePath = document.uri.path
-  } else if (tempUri.path[0] === '/') {
-    const root = vscode.workspace.getWorkspaceFolder(document.uri)
-    if (root) {
-      resourcePath = path.join(root.uri.fsPath, tempUri.path)
-    }
+  } else if (link[0] === '/') {
+    resourcePath = tempUri.path
   } else {
     resourcePath = path.join(base, tempUri.path)
   }
-
-  return OpenDocumentLinkCommand.createCommandUri(resourcePath, tempUri.fragment)
-}
-
-function matchAll (
-  pattern: RegExp,
-  text: string
-): Array<RegExpMatchArray> {
-  const out: RegExpMatchArray[] = []
-  pattern.lastIndex = 0
-  let match: RegExpMatchArray | null
-  while ((match = pattern.exec(text))) {
-    out.push(match)
-  }
-  return out
+  const sanitizedResourcePath = isSchemeBlacklisted(link) ? '#' : resourcePath
+  return OpenDocumentLinkCommand.createCommandUri(sanitizedResourcePath, tempUri.fragment)
 }
 
 export default class LinkProvider implements vscode.DocumentLinkProvider {
-  private readonly linkPattern = /(\[[^\]]*\]\(\s*)((([^\s()]|\(\S*?\))+))\s*(".*?")?\)/g;
-  private readonly referenceLinkPattern = /(\[([^\]]+)\]\[\s*?)([^\s\]]*?)\]/g;
-  private readonly definitionPattern = /^([\t ]*\[([^\]]+)\]:\s*)(\S+)/gm;
+  private engine: any
 
-  public provideDocumentLinks (
+  constructor (engine) {
+    this.engine = engine
+  }
+
+  public async provideDocumentLinks (
     document: vscode.TextDocument,
     _token: vscode.CancellationToken
-  ): vscode.DocumentLink[] {
+  ): Promise<vscode.DocumentLink[]> {
     const base = path.dirname(document.uri.fsPath)
     const text = document.getText()
 
-    return this.providerInlineLinks(text, document, base)
-      .concat(this.provideReferenceLinks(text, document, base))
-  }
+    const adParser = await this.engine.getEngine(document.uri)
+    adParser.convertUsingJavascript(text, document, false, 'html', true)
 
-  private providerInlineLinks (
-    text: string,
-    document: vscode.TextDocument,
-    base: string
-  ): vscode.DocumentLink[] {
     const results: vscode.DocumentLink[] = []
-    for (const match of matchAll(this.linkPattern, text)) {
-      const pre = match[1]
-      const link = match[2]
-      const offset = (match.index || 0) + pre.length
-      const linkStart = document.positionAt(offset)
-      const linkEnd = document.positionAt(offset + link.length)
-      try {
-        results.push(new vscode.DocumentLink(
-          new vscode.Range(linkStart, linkEnd),
-          normalizeLink(document, link, base)))
-      } catch (e) {
-        // noop
+    const lines = adParser.document.getSourceLines()
+
+    // includes from the reader are resolved correctly but the line numbers may be offset and not exactly match the document
+    let baseDocumentProcessorIncludes = adParser.baseDocumentIncludeItems
+    const includeDirective = /^(\\)?include::([^[][^[]*)\[([^\n]+)?\]$/
+    // get includes from document text. These may be inside ifeval or ifdef but the line numbers are correct.
+    const baseDocumentRegexIncludes = new Map()
+    lines.forEach((line, index) => {
+      const match = includeDirective.exec(line)
+      if (match) {
+        // match[2] is the include reference
+        baseDocumentRegexIncludes.set(index, match[2].length)
       }
-    }
+    })
 
-    return results
-  }
+    // find a corrected mapping for line numbers
+    const betterIncludeMatching = similarArrayMatch(
+      Array.from(baseDocumentRegexIncludes.keys()),
+      baseDocumentProcessorIncludes.map((elem) => {
+        return elem[1]
+      }))
 
-  private provideReferenceLinks (
-    text: string,
-    document: vscode.TextDocument,
-    base: string
-  ): vscode.DocumentLink[] {
-    const results: vscode.DocumentLink[] = []
+    // update line items in reader results
+    baseDocumentProcessorIncludes = baseDocumentProcessorIncludes.map((elem, index) => {
+      elem[1] = betterIncludeMatching[index]
+      return elem
+    })
 
-    const definitions = this.getDefinitions(text, document)
-    for (const match of matchAll(this.referenceLinkPattern, text)) {
-      let linkStart: vscode.Position
-      let linkEnd: vscode.Position
-      let reference = match[3]
-      if (reference) { // [text][ref]
-        const pre = match[1]
-        const offset = (match.index || 0) + pre.length
-        linkStart = document.positionAt(offset)
-        linkEnd = document.positionAt(offset + reference.length)
-      } else if (match[2]) { // [ref][]
-        reference = match[2]
-        const offset = (match.index || 0) + 1
-        linkStart = document.positionAt(offset)
-        linkEnd = document.positionAt(offset + match[2].length)
-      } else {
-        continue
-      }
-
-      try {
-        const link = definitions.get(reference)
-        if (link) {
-          results.push(new vscode.DocumentLink(
-            new vscode.Range(linkStart, linkEnd),
-            vscode.Uri.parse(`command:_asciidoc.moveCursorToPosition?${encodeURIComponent(JSON.stringify([link.linkRange.start.line, link.linkRange.start.character]))}`)))
-        }
-      } catch (e) {
-        // noop
-      }
-    }
-
-    for (const definition of Array.from(definitions.values())) {
-      try {
-        results.push(new vscode.DocumentLink(
-          definition.linkRange,
-          normalizeLink(document, definition.link, base)))
-      } catch (e) {
-        // noop
-      }
-    }
-
-    return results
-  }
-
-  private getDefinitions (text: string, document: vscode.TextDocument) {
-    const out = new Map<string, { link: string, linkRange: vscode.Range }>()
-    for (const match of matchAll(this.definitionPattern, text)) {
-      const pre = match[1]
-      const reference = match[2]
-      const link = match[3].trim()
-
-      const offset = (match.index || 0) + pre.length
-      const linkStart = document.positionAt(offset)
-      const linkEnd = document.positionAt(offset + link.length)
-
-      out.set(reference, {
-        link: link,
-        linkRange: new vscode.Range(linkStart, linkEnd),
+    // create include links
+    if (baseDocumentProcessorIncludes) {
+      baseDocumentProcessorIncludes.forEach((include) => {
+        const lineNo = include[1]
+        const documentLink = new vscode.DocumentLink(
+          new vscode.Range(
+            // don't link to the include:: part or the square bracket contents
+            new vscode.Position(lineNo, 9),
+            new vscode.Position(lineNo, include[2] + 9)),
+          normalizeLink(document, include[0], base))
+        documentLink.tooltip = localize('documentLink.tooltip', 'Open file') + ' ' + include[0]
+        results.push(documentLink)
       })
     }
-    return out
+    return results
   }
 }

--- a/src/features/documentLinkProvider.ts
+++ b/src/features/documentLinkProvider.ts
@@ -74,28 +74,26 @@ export default class LinkProvider implements vscode.DocumentLinkProvider {
     // find a corrected mapping for line numbers
     const betterIncludeMatching = similarArrayMatch(
       Array.from(baseDocumentRegexIncludes.keys()),
-      baseDocumentProcessorIncludes.map((elem) => {
-        return elem[1]
-      }))
+      baseDocumentProcessorIncludes.map((entry) => { return entry.position })
+    )
 
     // update line items in reader results
-    baseDocumentProcessorIncludes = baseDocumentProcessorIncludes.map((elem, index) => {
-      elem[1] = betterIncludeMatching[index]
-      return elem
+    baseDocumentProcessorIncludes = baseDocumentProcessorIncludes.map((entry) => {
+      return { ...entry, index: betterIncludeMatching[entry.index] }
     })
 
     // create include links
     if (baseDocumentProcessorIncludes) {
       const base = path.dirname(textDocument.uri.fsPath)
-      baseDocumentProcessorIncludes.forEach((include) => {
-        const lineNo = include[1]
+      baseDocumentProcessorIncludes.forEach((entry) => {
+        const lineNo = entry.position - 1
         const documentLink = new vscode.DocumentLink(
           new vscode.Range(
             // don't link to the include:: part or the square bracket contents
             new vscode.Position(lineNo, 9),
-            new vscode.Position(lineNo, include[2] + 9)),
-          normalizeLink(document, include[0], base))
-        documentLink.tooltip = localize('documentLink.tooltip', 'Open file') + ' ' + include[0]
+            new vscode.Position(lineNo, entry.length + 9)),
+          normalizeLink(document, entry.name, base))
+        documentLink.tooltip = localize('documentLink.tooltip', 'Open file') + ' ' + entry.name
         results.push(documentLink)
       })
     }

--- a/src/features/documentLinkProvider.ts
+++ b/src/features/documentLinkProvider.ts
@@ -53,7 +53,7 @@ export default class LinkProvider implements vscode.DocumentLinkProvider {
     _token: vscode.CancellationToken
   ): Promise<vscode.DocumentLink[]> {
     const asciidocParser = this.engine.getEngine()
-    const {document} = await asciidocParser.convertUsingJavascript(textDocument.getText(), textDocument, false, 'html', true)
+    const { document } = await asciidocParser.convertUsingJavascript(textDocument.getText(), textDocument, false, 'html', true)
 
     const results: vscode.DocumentLink[] = []
     const lines = document.getSourceLines()

--- a/src/features/previewContentProvider.ts
+++ b/src/features/previewContentProvider.ts
@@ -72,7 +72,7 @@ export class AsciidocContentProvider {
     // Content Security Policy
     const nonce = new Date().getTime() + '' + new Date().getMilliseconds()
     const csp = this.getCspForResource(sourceUri, nonce)
-    const body = await this.engine.render(sourceUri, config.previewFrontMatter === 'hide', asciidocDocument.getText(), false, 'html5', this.context, editor)
+    const {output: body} = await this.engine.render(sourceUri, config.previewFrontMatter === 'hide', asciidocDocument.getText(), false, 'html5', this.context, editor)
     const bodyClassesRegex = /<body(?:(?:\s+(?:id=".*"\s*)?class(?:\s*=\s*(?:"(.+?)"|'(.+?)')))+\s*)>/
     const bodyClasses = body.match(bodyClassesRegex)
     const bodyClassesVal = bodyClasses === null ? '' : bodyClasses[1]

--- a/src/features/previewContentProvider.ts
+++ b/src/features/previewContentProvider.ts
@@ -72,7 +72,7 @@ export class AsciidocContentProvider {
     // Content Security Policy
     const nonce = new Date().getTime() + '' + new Date().getMilliseconds()
     const csp = this.getCspForResource(sourceUri, nonce)
-    const {output: body} = await this.engine.render(sourceUri, config.previewFrontMatter === 'hide', asciidocDocument.getText(), false, 'html5', this.context, editor)
+    const { output: body } = await this.engine.render(sourceUri, config.previewFrontMatter === 'hide', asciidocDocument.getText(), false, 'html5', this.context, editor)
     const bodyClassesRegex = /<body(?:(?:\s+(?:id=".*"\s*)?class(?:\s*=\s*(?:"(.+?)"|'(.+?)')))+\s*)>/
     const bodyClasses = body.match(bodyClassesRegex)
     const bodyClassesVal = bodyClasses === null ? '' : bodyClasses[1]

--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -147,7 +147,7 @@ export namespace Import {
         .format('d-M-YYYY-HH-mm-ss-A.png')
         .toString() //default filename
       let alttext = '' //todo:...
-      const directory = this.getCurrentImagesDir()
+      const directory = await this.getCurrentImagesDir()
 
       // confirm directory is local--asciidoctor allows external URIs. test for
       // protocol (http, ftp, etc) to determine this
@@ -309,7 +309,7 @@ export namespace Import {
      * Reads the _nearest_ `:imagesdir:` attribute that appears _before_ the current selection
      * or cursor location, failing that figures it out from the API by converting the document and reading the attribute
      */
-    static getCurrentImagesDir () {
+    static async getCurrentImagesDir () {
       const text = vscode.window.activeTextEditor.document.getText()
 
       const imagesdir = /^[\t\f]*?:imagesdir:\s+(.+?)\s+$/gim
@@ -327,10 +327,12 @@ export namespace Import {
       }
 
       if (dir === '') {
-        const thisDocument = vscode.window.activeTextEditor.document
-        const adoc = new AsciidocParser(thisDocument.uri.fsPath)
-        adoc.parseText(thisDocument.getText(), thisDocument)
-        dir = adoc.document.getAttribute('imagesdir')
+        const textDocument = vscode.window.activeTextEditor.document
+        const extensionUri = vscode.Uri.file('') // won't be used anyway... needs refactoring!
+        const {document} = await new AsciidocParser(extensionUri).parseText(textDocument.getText(), textDocument)
+        if (document) {
+          dir = document.getAttribute('imagesdir')
+        }
       }
 
       return dir !== undefined ? dir : ''

--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -329,7 +329,7 @@ export namespace Import {
       if (dir === '') {
         const textDocument = vscode.window.activeTextEditor.document
         const extensionUri = vscode.Uri.file('') // won't be used anyway... needs refactoring!
-        const {document} = await new AsciidocParser(extensionUri).parseText(textDocument.getText(), textDocument)
+        const { document } = await new AsciidocParser(extensionUri).parseText(textDocument.getText(), textDocument)
         if (document) {
           dir = document.getAttribute('imagesdir')
         }

--- a/src/linkSanitizer.ts
+++ b/src/linkSanitizer.ts
@@ -1,0 +1,20 @@
+
+const BAD_PROTO_RE = /^(vbscript|javascript|data):/i
+const GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/i
+
+/**
+ * Disallow blacklisted URL types following MarkdownIt and the
+ * VS Code Markdown extension
+ * @param   {String}  href   The link address
+ * @returns {boolean}        Whether the link is valid
+ */
+export function isSchemeBlacklisted (href: string): boolean {
+  if (href && typeof (href) === 'string') {
+    const hrefCheck = href.trim()
+    if (BAD_PROTO_RE.test(hrefCheck)) {
+      // we still allow specific safe "data:image/" URIs
+      return !GOOD_DATA_RE.test(hrefCheck)
+    }
+  }
+  return false
+}

--- a/src/similarArrayMatch.ts
+++ b/src/similarArrayMatch.ts
@@ -1,0 +1,118 @@
+import { range } from './util/range'
+
+/**
+ * Calculate the cost for mapping between two different arrays
+ * @param {Array} haystack        an array of numbers contained but with offsets
+ *                                in `similarNeedles`
+ * @param {Array} similarNeedles  items matchable against the `haystack` array
+ * @returns {Array}               an array of arrays with costs for each item
+ *                                against each other item in the array.
+ */
+function calculateAdjacency (haystack, similarNeedles) {
+  // Calculate adjacency using a cost function
+  const rows = []
+  haystack.forEach((v1) => {
+    const row = []
+    similarNeedles.forEach((v2) => {
+      // Distance-like cost function
+      row.push(Math.abs(v1 - v2))
+    })
+    rows.push(row)
+  })
+  return rows
+}
+
+/**
+ * Returns the indexes in the adjacency matrix of lowest cost
+ * @param {Array} adjacency     Cost mappings between arrays
+ * @param {Array} col
+ * @returns {Array}             Returns the index and the error term
+ */
+function columnMin (adjacency, col, removals) {
+  const colValues = []
+  adjacency.forEach((row, rowIndex) => {
+    if (rowIndex <= Math.max(...removals)) {
+      // values must be strictly increasing
+      colValues.push(Infinity)
+    } else {
+      colValues.push(row[col])
+    }
+  })
+  const chosenIndex = colValues.indexOf(Math.min(...colValues))
+  return [chosenIndex, colValues[chosenIndex]]
+}
+
+/**
+ * Given an adjacency matrix, select the lowest cost item
+ * and return the matching item in the `haystack` array.
+ * @param {Array} haystack  list of items from which lowest cost
+ *                          array will be provided
+ * @param {Array} adjacency list of costs of selecting items
+ * @returns {Array}         returns a match and as an error term
+ *                          the differences in lines
+ */
+function findNearest (haystack, adjacency) {
+  const selectedEntries = []
+  const removals = []
+  let errorSum = 0
+  adjacency[0].forEach((_entry, idx) => {
+    const [removedEntry, errorTerm] = columnMin(adjacency, idx, removals)
+    selectedEntries.push(haystack[removedEntry])
+    removals.push(removedEntry)
+    if (errorTerm !== Infinity) {
+      errorSum += errorTerm
+    }
+  })
+  return [selectedEntries, errorSum]
+}
+
+function arrIsIncreasing (num) {
+  if (num.length === 1) {
+    return true
+  }
+  const numDirection = num[1] - num[0]
+  for (let i = 0; i < num.length - 1; i++) {
+    if (numDirection * (num[i + 1] - num[i]) <= 0) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Given a set of `matchableItems` known to be contained in
+ * `candidateItems` but potentially with offsets return a reasonable
+ * guess at which `candidateItems` are the correct match and return these
+ * @param   {Array} candidateItems list of items containing items similar
+ *                                 to matchableItems
+ * @param   {Array} matchableItems items which can be matched against
+ *                                 candidateItems
+ * @returns {Array}                items in candidateItems which are closest
+ *                                 matches to matchableItems
+ */
+export function similarArrayMatch (candidateItems, matchableItems) {
+  // if the arrays are equal because they are in strict ascending order
+  // we can simply return the candidateItems
+  if (candidateItems.length === matchableItems.length) {
+    return candidateItems
+  } else {
+    // we assume a maximum error between lines and converter of +/- 10 lines
+    // We sum the error term over all matchableItems and choose the lowest
+    // value
+    const offsets = range(-10, 10)
+    const options = new Map()
+    offsets.forEach((offset) => {
+      const newMatchableItems = matchableItems.map((x) => x + offset)
+      const adj = calculateAdjacency(candidateItems, newMatchableItems)
+      const [result, error] = findNearest(candidateItems, adj)
+      options.set(error, result)
+    })
+    // Enforce that options have strictly ascending arrays
+    options.forEach((lines, key) => {
+      if (!arrIsIncreasing(lines)) {
+        options.delete(key)
+      }
+    })
+    return options.get(Math.min(...options.keys()))
+  }
+}

--- a/src/test/documentLinkProvider.test.ts
+++ b/src/test/documentLinkProvider.test.ts
@@ -7,6 +7,8 @@ import 'mocha'
 import * as vscode from 'vscode'
 import LinkProvider from '../features/documentLinkProvider'
 import { InMemoryDocument } from './inMemoryDocument'
+import SymbolProvider from "../features/documentSymbolProvider";
+import { createNewAsciidocEngine } from "./engine";
 
 const testFileName = vscode.Uri.file('test.md')
 
@@ -17,24 +19,69 @@ const noopToken = new class implements vscode.CancellationToken {
   get isCancellationRequested () { return false }
 }()
 
-function getLinksForFile (fileContents: string) {
+async function getLinksForFile (fileContents: string) {
   const doc = new InMemoryDocument(testFileName, fileContents)
-  const provider = new LinkProvider()
+  const provider = new LinkProvider(createNewAsciidocEngine())
   return provider.provideDocumentLinks(doc, noopToken)
 }
 
-suite('asciidoc.DocumentLinkProvider', () => {
-  test('Should not return anything for empty document', () => {
-    const links = getLinksForFile('')
+function assertRangeEqual (expected: vscode.Range, actual: vscode.Range) {
+  assert.strictEqual(expected.start.line, actual.start.line)
+  assert.strictEqual(expected.start.character, actual.start.character)
+  assert.strictEqual(expected.end.line, actual.end.line)
+  assert.strictEqual(expected.end.character, actual.end.character)
+}
+
+suite('asciidoc.DocumentLinkProvider', async () => {
+  test('Should not return anything for empty document', async () => {
+    const links = await getLinksForFile('')
     assert.strictEqual(links.length, 0)
   })
 
-  test('Should not return anything for simple document without include', () => {
-    const links = getLinksForFile(`= a
+  test('Should not return anything for simple document without include', async () => {
+    const links = await getLinksForFile(`= a
 
 b
 
 c`)
     assert.strictEqual(links.length, 0)
+  })
+
+  test('Should detect basic include', async () => {
+    const links = await getLinksForFile(`a
+
+include::b.adoc[]
+
+c`)
+    assert.strictEqual(links.length, 1)
+    const [link] = links
+    assertRangeEqual(link.range, new vscode.Range(2, 9, 2, 15))
+  })
+
+  test('Should detect basic workspace include', async () => {
+    {
+      const links = await getLinksForFile(`a
+
+include::./b.adoc[]
+
+c`)
+      assert.strictEqual(links.length, 1)
+      const [link] = links
+      assertRangeEqual(link.range, new vscode.Range(2, 9, 2, 17))
+    }
+    {
+      const links = await getLinksForFile(`a
+
+[source,ruby]
+----
+include::core.rb[tag=parse]
+----
+
+b
+`)
+      assert.strictEqual(links.length, 1)
+      const [link] = links
+      assertRangeEqual(link.range, new vscode.Range(4, 9, 4, 16))
+    }
   })
 })

--- a/src/test/documentLinkProvider.test.ts
+++ b/src/test/documentLinkProvider.test.ts
@@ -7,8 +7,7 @@ import 'mocha'
 import * as vscode from 'vscode'
 import LinkProvider from '../features/documentLinkProvider'
 import { InMemoryDocument } from './inMemoryDocument'
-import SymbolProvider from "../features/documentSymbolProvider";
-import { createNewAsciidocEngine } from "./engine";
+import { createNewAsciidocEngine } from './engine'
 
 const testFileName = vscode.Uri.file('test.md')
 

--- a/src/util/range.ts
+++ b/src/util/range.ts
@@ -1,0 +1,13 @@
+
+export const range = function (min, max) {
+  // If only one number is provided, start at one
+  if (max === undefined) {
+    max = min
+    min = 1
+  }
+
+  // Create a ranged array
+  return Array.from(new Array(max - min + 1).keys()).map(function (num) {
+    return num + min
+  })
+}


### PR DESCRIPTION
**What I did:**

*    Used an IncludeProcessor to find the link text and reader line numbers for includes and then regex parsed the document to identify line numbers more precisely since the Asciidoctor reader is "imprecise" (optimised for speed, not accuracy).
* Created a line number alignment algorithm to process include line numbers from the IncludeProcessor and from regex parsing to "match up" the relevant lines.
* Abstracted the link sanitizer code previously only used in the preview as part of AsciidoctorWebViewConverter to be part of the normalizeLinks routine so that preview and DocumentLinks use the same implementation.

**Implementation limitations:**

Items within an `ifdef` or `ifeval` which aren't processed won't receive DocumentLinks because they're not handled by the include processor. But to avoid this would require quite sophisticated external logic in this extension and doesn't currently seem worthwhile.

**What I didn't do:**

Write a test. I'm not entirely sure how but I haven't spent any time on it. I have commented out the tests because it was causing the linter to be argumentative.
I can work on this if you would prefer to have this done prior to merging but I would like to see if we think this PR is heading in the right direction.

I've done some initial testing and the logic seems to work across a range of documents that were close at hand... but some more testing would be appreciated.

_NOTE:_ Originally this PR was part of #474 but this was trying to do inline links as well and this was not possible and I was unable to effectively rebase it so I've taken a diff of the final commit to the originating commit to generate this PR and rebased on the current master.
