### PR TITLE
Add option stem_renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -639,6 +639,11 @@
 				}
 			}
 		},
+		"asciidoctor-mathjax3": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/asciidoctor-mathjax3/-/asciidoctor-mathjax3-0.0.2.tgz",
+			"integrity": "sha512-OjStw+Wb678rC5s9qB61BuxhuJ3xOjK36tgdTSrSaNMAXWHTC0p47MUAKP9r9/R9CnsW2tszSVi2pYrNUvNOOw=="
+		},
 		"asciidoctor-opal-runtime": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -529,8 +529,7 @@
 		"ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
 		},
 		"ansi-regex": {
 			"version": "5.0.1",
@@ -640,9 +639,13 @@
 			}
 		},
 		"asciidoctor-mathjax3": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/asciidoctor-mathjax3/-/asciidoctor-mathjax3-0.0.2.tgz",
-			"integrity": "sha512-OjStw+Wb678rC5s9qB61BuxhuJ3xOjK36tgdTSrSaNMAXWHTC0p47MUAKP9r9/R9CnsW2tszSVi2pYrNUvNOOw=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/asciidoctor-mathjax3/-/asciidoctor-mathjax3-0.1.1.tgz",
+			"integrity": "sha512-pSiLK5JfQJ9nsFybaRnx1uUQ6pdNeWqOGQgIBiQ3G8tpnGiAKCgwzv55aI9Z8shQX8RYMdirJ6RzQOkfK5bkng==",
+			"requires": {
+				"juice": "^8.0.0",
+				"mathjax-full": "^3.2.0"
+			}
 		},
 		"asciidoctor-opal-runtime": {
 			"version": "0.3.3",
@@ -767,8 +770,7 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -903,7 +905,6 @@
 			"version": "1.0.0-rc.10",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
 			"integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
-			"dev": true,
 			"requires": {
 				"cheerio-select": "^1.5.0",
 				"dom-serializer": "^1.3.2",
@@ -917,8 +918,7 @@
 				"tslib": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-					"dev": true
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 				}
 			}
 		},
@@ -926,7 +926,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
 			"integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
-			"dev": true,
 			"requires": {
 				"css-select": "^4.1.3",
 				"css-what": "^5.0.1",
@@ -1093,8 +1092,7 @@
 		"commander": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-			"dev": true
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
 		},
 		"component-emitter": {
 			"version": "1.3.0",
@@ -1194,7 +1192,6 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
 			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
-			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0",
 				"css-what": "^5.0.0",
@@ -1206,8 +1203,7 @@
 		"css-what": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
-			"dev": true
+			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
 		},
 		"debug": {
 			"version": "4.3.2",
@@ -1296,7 +1292,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
 			"integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
 				"domhandler": "^4.2.0",
@@ -1306,14 +1301,12 @@
 		"domelementtype": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-			"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-			"dev": true
+			"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
 		},
 		"domhandler": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
 			"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^2.2.0"
 			}
@@ -1322,7 +1315,6 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
 			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
-			"dev": true,
 			"requires": {
 				"dom-serializer": "^1.0.1",
 				"domelementtype": "^2.2.0",
@@ -1378,8 +1370,7 @@
 		"entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-			"dev": true
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
 		},
 		"envinfo": {
 			"version": "7.8.1",
@@ -1452,6 +1443,11 @@
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
+		},
+		"escape-goat": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+			"integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw=="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -1833,6 +1829,11 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true
+		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
 		},
 		"espree": {
 			"version": "7.3.1",
@@ -2499,7 +2500,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
 			"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^2.0.1",
 				"domhandler": "^4.0.0",
@@ -2995,6 +2995,18 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"juice": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/juice/-/juice-8.0.0.tgz",
+			"integrity": "sha512-LRCfXBOqI1wt+zYR/5xwDnf+ZyiJiDt44DGZaBSAVwZWyWv3BliaiGTLS6KCvadv3uw6XGiPPFcTfY7CdF7Z/Q==",
+			"requires": {
+				"cheerio": "^1.0.0-rc.3",
+				"commander": "^6.1.0",
+				"mensch": "^0.3.4",
+				"slick": "^1.12.2",
+				"web-resource-inliner": "^5.0.0"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3217,6 +3229,17 @@
 				}
 			}
 		},
+		"mathjax-full": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.0.tgz",
+			"integrity": "sha512-D2EBNvUG+mJyhn+M1C858k0f2Fc4KxXvbEX2WCMXroV10212JwfYqaBJ336ECBSz5X9L5LRoamxb7AJtg3KaJA==",
+			"requires": {
+				"esm": "^3.2.25",
+				"mhchemparser": "^4.1.0",
+				"mj-context-menu": "^0.6.1",
+				"speech-rule-engine": "^3.3.3"
+			}
+		},
 		"md5": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -3244,6 +3267,11 @@
 				"readable-stream": "^2.0.1"
 			}
 		},
+		"mensch": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
+			"integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g=="
+		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3255,6 +3283,11 @@
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
+		},
+		"mhchemparser": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
+			"integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
 		},
 		"micromatch": {
 			"version": "3.1.10",
@@ -3416,6 +3449,11 @@
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
 			}
+		},
+		"mj-context-menu": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+			"integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
 		},
 		"mkdirp": {
 			"version": "1.0.4",
@@ -3658,6 +3696,14 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
+		"node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
+		},
 		"node-releases": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
@@ -3703,7 +3749,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
 			"integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
-			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0"
 			}
@@ -3950,14 +3995,12 @@
 		"parse5": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-			"dev": true
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
 		},
 		"parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
 			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-			"dev": true,
 			"requires": {
 				"parse5": "^6.0.1"
 			}
@@ -4451,6 +4494,11 @@
 				}
 			}
 		},
+		"slick": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+			"integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc="
+		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -4681,6 +4729,23 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
 			"integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
 			"dev": true
+		},
+		"speech-rule-engine": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.3.3.tgz",
+			"integrity": "sha512-0exWw+0XauLjat+f/aFeo5T8SiDsO1JtwpY3qgJE4cWt+yL/Stl0WP4VNDWdh7lzGkubUD9lWP4J1ASnORXfyQ==",
+			"requires": {
+				"commander": ">=7.0.0",
+				"wicked-good-xpath": "^1.3.0",
+				"xmldom-sre": "^0.1.31"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+					"integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
+				}
+			}
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -5026,6 +5091,11 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -5270,6 +5340,11 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
+		"valid-data-url": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+			"integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA=="
+		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -5387,6 +5462,50 @@
 				"graceful-fs": "^4.1.2"
 			}
 		},
+		"web-resource-inliner": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-5.0.0.tgz",
+			"integrity": "sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==",
+			"requires": {
+				"ansi-colors": "^4.1.1",
+				"escape-goat": "^3.0.0",
+				"htmlparser2": "^4.0.0",
+				"mime": "^2.4.6",
+				"node-fetch": "^2.6.0",
+				"valid-data-url": "^3.0.0"
+			},
+			"dependencies": {
+				"domhandler": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+					"integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+					"requires": {
+						"domelementtype": "^2.0.1"
+					}
+				},
+				"htmlparser2": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+					"integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^3.0.0",
+						"domutils": "^2.0.0",
+						"entities": "^2.0.0"
+					}
+				},
+				"mime": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+					"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+				}
+			}
+		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+		},
 		"webpack": {
 			"version": "5.60.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.60.0.tgz",
@@ -5487,6 +5606,15 @@
 			"integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
 			"dev": true
 		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5522,6 +5650,11 @@
 				"has-tostringtag": "^1.0.0",
 				"is-typed-array": "^1.1.7"
 			}
+		},
+		"wicked-good-xpath": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+			"integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
 		},
 		"wildcard": {
 			"version": "2.0.0",
@@ -5588,6 +5721,11 @@
 			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
 			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
 			"dev": true
+		},
+		"xmldom-sre": {
+			"version": "0.1.31",
+			"resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+			"integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -521,7 +521,7 @@
 		"@orcid/bibtex-parse-js": "^0.0.25",
 		"@types/vscode": "^1.31.0",
 		"asciidoctor-kroki": "^0.15.4",
-		"asciidoctor-mathjax3": "0.0.2",
+		"asciidoctor-mathjax3": "^0.1.1",
 		"eslint-config-standard": "^16.0.3",
 		"file-url": "^3.0.0",
 		"follow-redirects": "^1.14.7",

--- a/package.json
+++ b/package.json
@@ -416,6 +416,15 @@
 					"default": false,
 					"description": "%asciidoc.use_kroki.desc%"
 				},
+				"asciidoc.stem_renderer": {
+					"type": "string",
+					"enum": [
+						"MathJax2",
+						"MathJax3"
+					],
+					"default": "MathJax2",
+					"description": "%asciidoc.stem_renderer.desc%"
+				},
 				"asciidoc.wkhtmltopdf_path": {
 					"type": "string",
 					"default": "",
@@ -512,6 +521,7 @@
 		"@orcid/bibtex-parse-js": "^0.0.25",
 		"@types/vscode": "^1.31.0",
 		"asciidoctor-kroki": "^0.15.4",
+		"asciidoctor-mathjax3": "0.0.2",
 		"eslint-config-standard": "^16.0.3",
 		"file-url": "^3.0.0",
 		"follow-redirects": "^1.14.7",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,9 +1,8 @@
 {
 	"displayName": "AsciiDoc",
 	"description": "Provides rich language support for AsciiDoc.",
-
 	"asciidoc.exportAsPDF.title": "Export document as PDF",
-	"asciidoc.pasteImage.title" : "Paste Image",
+	"asciidoc.pasteImage.title": "Paste Image",
 	"asciidoc.preview.title": "Open Preview",
 	"asciidoc.preview.refresh.title": "Refresh Preview",
 	"asciidoc.preview.toggleLock.title": "Toggle Preview Locking",
@@ -16,7 +15,6 @@
 	"asciidoc.showLockedPreviewToSide.title": "Open Locked Preview to the Side",
 	"asciidoc.showPreviewSecuritySelector.title": "Change Preview Security Settings",
 	"asciidoc.showSource.title": "Show Source",
-
 	"asciidoc.asciidoctor_command.desc": "Full path for the asciidoctor binary/executable",
 	"asciidoc.asciidoctorpdf_command.desc": "Full path for the asciidoctor binary/executable",
 	"asciidoc.preview.attributes.desc": "Set attributes to be used in the preview. Attributes need to be written as an object of type {string: string}",
@@ -39,6 +37,7 @@
 	"asciidoc.use_asciidoctor_js.desc": "Use asciidoctor js instead of the 'asciidoctor_command'",
 	"asciidoc.use_asciidoctorpdf.desc": "Use asciidoctor-pdf instead of the integrated renderer",
 	"asciidoc.use_kroki.desc": "Enable kroki integration to generate diagrams.",
+	"asciidoc.stem_renderer.desc": "Sets stem renderer to LaTeX formulae.",
 	"asciidoc.wkhtmltopdf_path.desc": "Full path for the wkhtmltopdf binary/executable",
 	"asciidoc.forceUnixStyleSeparator.desc": "Force set the file separator style to unix style. If set false, separator style will follow the system style.",
 	"asciidoc.preview.openAsciiDocLinks.desc": "How should clicking on links to AsciiDoc files be handled in the preview.",


### PR DESCRIPTION
Among the several modern asciidoctor applications, the latest version of MathJax is employed.
For example, asciidoctor-reveal.js uses it. Thus, the preview of documentation with the latest is in demand. However, we cannot do that because the viewer uses compiled version of asciidoctor, which still uses the old MathJax for compatibility. This pull request adds an option `stem_renderer` to specify the render for stem notation. Note that I add only two enums `MathJax2` as default and `MathJax3`. In the future, I would like another render, i.e., KaTeX. However, at this moment, I failed for unclear reasons.
Let me add it at another pull request.

Thanks for the great software, I enjoy to use this on vscode.dev.
Cheers.


