### PR TITLE
Issue 501 preview style regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.9.4
+
+- Fix regression in default preview styling (#501)
+
 ## 2.9.3
 
 - Build the web extension when packaging (#500)

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -18,6 +18,8 @@ export class AsciidocParser {
   public baseDocumentIncludeItems = null
 
   constructor (extensionUri: vscode.Uri, private errorCollection: vscode.DiagnosticCollection = null) {
+    // Asciidoctor.js in the browser environment works with URIs however for desktop clients
+    // the stylesdir attribute is expected to look like a file system path (especially on Windows)
     if (process.env.BROWSER_ENV) {
       this.stylesdir = vscode.Uri.joinPath(extensionUri, 'media').toString()
     } else {

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -18,7 +18,11 @@ export class AsciidocParser {
   public baseDocumentIncludeItems = null
 
   constructor (extensionUri: vscode.Uri, private errorCollection: vscode.DiagnosticCollection = null) {
-    this.stylesdir = vscode.Uri.joinPath(extensionUri, 'media').toString()
+    if (process.env.BROWSER_ENV) {
+      this.stylesdir = vscode.Uri.joinPath(extensionUri, 'media').toString()
+    } else {
+      this.stylesdir = vscode.Uri.joinPath(extensionUri, 'media').fsPath
+    }
   }
 
   public getMediaDir (text) {


### PR DESCRIPTION
See #501 for discussion. I will be happy to take a review.

I'm a little surprised the underlying VS Code API doesn't handle this more elegantly but I haven't found a way to do this other than to check the environment.

I've decided to retain the `toString()` for the web environment and for others I think `.fsPath` is a stable referent.

I've added a CHANGELOG entry since in 2.9.3 we broke some user functionality and should probably do a release to ensure this does not linger.