### PR TITLE
resolves #509 restructure code for testing

### DIFF
--- a/src/test/exportAsPDF.test.ts
+++ b/src/test/exportAsPDF.test.ts
@@ -1,0 +1,33 @@
+import * as assert from 'assert'
+import 'mocha'
+import * as vscode from 'vscode'
+import { _generateCoverHtmlContent } from '../commands/exportAsPDF'
+
+const asciidoctor = require('@asciidoctor/core')
+const processor = asciidoctor()
+
+suite('asciidoc.exportAsPDF', async () => {
+  test('Should create an HTML cover page without title page logo', async () => {
+    const document = processor.load(`= The Intrepid Chronicles
+Kismet R. Lee <kismet@asciidoctor.org>`)
+    const coverHtmlContent = _generateCoverHtmlContent(undefined, __dirname, document, vscode.Uri.parse(''))
+    assert.strictEqual(coverHtmlContent, `<!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="file:///media/all-centered.css">
+  </head>
+  <body>
+  <div class="outer">
+    <div class="middle">
+      <div class="inner">
+
+        <h1>The Intrepid Chronicles</h1>
+        p>Kismet R. Lee &lt;kismet@asciidoctor.org&gt;</p>
+      </div>
+    </div>
+  </div>
+  </body>
+  </html>`)
+  })
+})


### PR DESCRIPTION
#### What I did

- Fix #509 
- Simplify condition from `if (!(pdfUri === null || pdfUri === undefined))` to `if (pdfUri)`
- Use `isAttribute` to check if `showTitlePage` is defined
- Extract code into a function for testing: `_generateCoverHtmlContent`
- Use `try/catch` around `await` instead of using `then` and `catch`

resolves #509 