### PR TITLE
Reduce bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,8 @@
 		"@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true
 		},
 		"@types/eslint": {
 			"version": "7.28.2",
@@ -194,7 +195,8 @@
 		"@types/vscode": {
 			"version": "1.59.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.59.0.tgz",
-			"integrity": "sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ=="
+			"integrity": "sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ==",
+			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.31.1",
@@ -731,7 +733,8 @@
 		"big-integer": {
 			"version": "1.6.48",
 			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+			"dev": true
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -743,6 +746,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
 			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"dev": true,
 			"requires": {
 				"buffers": "~0.1.1",
 				"chainsaw": "~0.1.0"
@@ -757,7 +761,8 @@
 		"bluebird": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+			"dev": true
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -817,12 +822,14 @@
 		"buffer-indexof-polyfill": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+			"dev": true
 		},
 		"buffers": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+			"dev": true
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -873,6 +880,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
 			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"dev": true,
 			"requires": {
 				"traverse": ">=0.3.0 <0.4"
 			}
@@ -1166,7 +1174,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -1328,6 +1337,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
@@ -1635,7 +1645,8 @@
 		"eslint-config-standard": {
 			"version": "16.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
-			"integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg=="
+			"integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -2262,6 +2273,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
 			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -2273,6 +2285,7 @@
 					"version": "0.5.5",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -2324,6 +2337,7 @@
 			"version": "7.1.7",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
 			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2382,7 +2396,8 @@
 		"graceful-fs": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -2506,6 +2521,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
 			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"dev": true,
 			"requires": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -2516,6 +2532,7 @@
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
 					"requires": {
 						"debug": "4"
 					}
@@ -2900,7 +2917,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -3018,7 +3036,8 @@
 		"listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+			"dev": true
 		},
 		"load-json-file": {
 			"version": "4.0.0",
@@ -3594,11 +3613,6 @@
 				"lodash": "^4.17.15"
 			}
 		},
-		"moment": {
-			"version": "2.29.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4052,7 +4066,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -4130,6 +4145,7 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -4143,7 +4159,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				}
 			}
 		},
@@ -4260,6 +4277,7 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -4354,7 +4372,8 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
@@ -4810,6 +4829,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			},
@@ -4817,7 +4837,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
 				}
 			}
 		},
@@ -5018,7 +5039,8 @@
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+			"dev": true
 		},
 		"ts-loader": {
 			"version": "4.5.0",
@@ -5189,6 +5211,7 @@
 			"version": "0.10.11",
 			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
 			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"dev": true,
 			"requires": {
 				"big-integer": "^1.6.17",
 				"binary": "~0.3.0",
@@ -5246,7 +5269,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "8.3.2",
@@ -5332,6 +5356,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
 			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
+			"dev": true,
 			"requires": {
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "^5.0.0",
@@ -5343,6 +5368,7 @@
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
 					"requires": {
 						"debug": "4"
 					}
@@ -5351,6 +5377,7 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
 					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+					"dev": true,
 					"requires": {
 						"agent-base": "6",
 						"debug": "4"
@@ -5360,6 +5387,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}

--- a/package.json
+++ b/package.json
@@ -485,6 +485,7 @@
 		"@types/lodash.throttle": "^4.1.3",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "^8.10.66",
+		"@types/vscode": "^1.31.0",
 		"@typescript-eslint/eslint-plugin": "^4.31.1",
 		"@typescript-eslint/parser": "^4.31.1",
 		"copy-webpack-plugin": "^9.0.1",
@@ -492,6 +493,7 @@
 		"eslint-plugin-import": "^2.20.2",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-promise": "^5.1.0",
+		"eslint-config-standard": "^16.0.3",
 		"lodash.throttle": "^4.1.1",
 		"mocha": "^9.1.3",
 		"mocha-junit-reporter": "^1.23.3",
@@ -509,15 +511,11 @@
 		"@asciidoctor/core": "2.2.6",
 		"@asciidoctor/docbook-converter": "^2.0.0",
 		"@orcid/bibtex-parse-js": "^0.0.25",
-		"@types/vscode": "^1.31.0",
 		"asciidoctor-kroki": "^0.15.4",
-		"eslint-config-standard": "^16.0.3",
 		"file-url": "^3.0.0",
 		"follow-redirects": "^1.14.7",
 		"https-proxy-agent": "^4.0.0",
-		"moment": "^2.14.1",
 		"uuid": "^8.3.2",
-		"vscode-nls": "^4.1.1",
-		"vscode-test": "^1.4.0"
+		"vscode-nls": "^4.1.1"
 	}
 }

--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { spawn } from 'child_process'
-import * as moment from 'moment'
 import * as fs from 'fs'
 
 import { AsciidocParser } from './asciidocParser'
@@ -143,9 +142,12 @@ export namespace Import {
 
       const editor = vscode.window.activeTextEditor
 
-      let filename = moment()
-        .format('d-M-YYYY-HH-mm-ss-A.png')
-        .toString() //default filename
+      const currentDateString = new Date()
+        .toISOString()
+        .replace(':', '-')
+        .replace('.', '-')
+      //default filename
+      let filename = `${currentDateString}.png`
       let alttext = '' //todo:...
       const directory = await this.getCurrentImagesDir()
 


### PR DESCRIPTION
#### What I Did

- Move `@types/vscode` to `devDependencies`
- Move `eslint-config-standard` to `devDependencies`
- Move `vscode-test` to `devDependencies`
- Replace `moment()` by built-in `Date`. Moment is 289.7kB minified: https://bundlephobia.com/package/moment@2.29.1

