### PR TITLE
resolves #497 introduce a load function

### DIFF
--- a/src/asciidoctorFindIncludeProcessor.ts
+++ b/src/asciidoctorFindIncludeProcessor.ts
@@ -5,7 +5,7 @@ interface IncludeEntry {
   length: string,
 }
 
-interface IncludeItems extends Array<IncludeEntry>{}
+export interface IncludeItems extends Array<IncludeEntry>{}
 
 let baseDocIncludes: IncludeItems = []
 let includeIndex = 0

--- a/src/features/documentLinkProvider.ts
+++ b/src/features/documentLinkProvider.ts
@@ -48,15 +48,12 @@ export default class LinkProvider implements vscode.DocumentLinkProvider {
     this.engine = engine
   }
 
-  public provideDocumentLinks (
-    textDocument: vscode.TextDocument,
-    _token: vscode.CancellationToken
-  ): vscode.DocumentLink[] {
+  public provideDocumentLinks (textDocument: vscode.TextDocument, _token: vscode.CancellationToken): vscode.DocumentLink[] {
     const asciidocParser = this.engine.getEngine()
-    const { document } = asciidocParser.convertUsingJavascript(textDocument.getText(), textDocument, false, 'webview-html5', true)
+    const { document, baseDocumentIncludeItems } = asciidocParser.load(textDocument)
 
     // includes from the reader are resolved correctly but the line numbers may be offset and not exactly match the document
-    let baseDocumentProcessorIncludes = asciidocParser.baseDocumentIncludeItems
+    let baseDocumentProcessorIncludes = baseDocumentIncludeItems
     const includeDirective = /^(\\)?include::([^[][^[]*)\[([^\n]+)?\]$/
     // get includes from document text. These may be inside ifeval or ifdef but the line numbers are correct.
     const baseDocumentRegexIncludes = new Map()

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -4,7 +4,8 @@
 
 import * as vscode from 'vscode'
 import { AsciidocEngine } from '../asciidocEngine'
-import { TableOfContentsProvider, SkinnyTextDocument, TocEntry } from '../tableOfContentsProvider'
+import { TableOfContentsProvider, TocEntry } from '../tableOfContentsProvider'
+import { SkinnyTextDocument } from '../util/document'
 
 interface AsciidocSymbol {
   readonly level: number;

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -7,7 +7,7 @@ import { disposeAll } from '../util/dispose'
 import { isAsciidocFile } from '../util/file'
 import { Lazy, lazy } from '../util/lazy'
 import AdocDocumentSymbolProvider from './documentSymbolProvider'
-import { SkinnyTextDocument } from '../tableOfContentsProvider'
+import { SkinnyTextDocument } from '../util/document'
 
 export interface WorkspaceAsciidocDocumentProvider {
   getAllAsciidocDocuments(): Promise<Iterable<SkinnyTextDocument>>;

--- a/src/tableOfContentsProvider.ts
+++ b/src/tableOfContentsProvider.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode'
 import { AsciidocEngine } from './asciidocEngine'
 import { githubSlugifier, Slug } from './slugify'
+import { SkinnyTextDocument } from './util/document'
 
 export interface TocEntry {
   readonly slug: Slug;
@@ -12,15 +13,6 @@ export interface TocEntry {
   readonly level: number;
   readonly line: number;
   readonly location: vscode.Location;
-}
-
-export interface SkinnyTextDocument {
-  readonly uri: vscode.Uri;
-  readonly lineCount: number;
-
-  getText(): string;
-
-  lineAt(line: number): vscode.TextLine;
 }
 
 export class TableOfContentsProvider {

--- a/src/util/document.ts
+++ b/src/util/document.ts
@@ -1,0 +1,42 @@
+import { TextLine, Uri } from 'vscode'
+
+export interface SkinnyTextDocument {
+  /**
+   * The associated uri for this document.
+   *
+   * *Note* that most documents use the `file`-scheme, which means they are files on disk. However, **not** all documents are
+   * saved on disk and therefore the `scheme` must be checked before trying to access the underlying file or siblings on disk.
+   *
+   * @see {@link FileSystemProvider}
+   * @see {@link TextDocumentContentProvider}
+   */
+  readonly uri: Uri;
+
+  /**
+   * The file system path of the associated resource. Shorthand
+   * notation for {@link TextDocument.uri TextDocument.uri.fsPath}. Independent of the uri scheme.
+   */
+  readonly fileName: string;
+
+  /**
+   * The number of lines in this document.
+   */
+  readonly lineCount: number;
+
+  /**
+   * Get the text of this document.
+   *
+   * @return The entire text.
+   */
+  getText(): string;
+
+  /**
+   * Returns a text line denoted by the line number. Note
+   * that the returned object is *not* live and changes to the
+   * document are not reflected.
+   *
+   * @param line A line number in [0, lineCount).
+   * @return A {@link TextLine line}.
+   */
+  lineAt(line: number): TextLine;
+}


### PR DESCRIPTION
#### What I Did

- Extract `SkinnyTextDocument` into `util/document.ts`
- Introduce a load function in `AsciidocParser` that returns the `Asciidoctor.Document` and a list of `IncludeEntry`
- Remove `getMediaDir` from `AsciidocParser` (was unused)
- Remove `baseDocumentIncludeItems` instance variable on `AsciidocParser` (since the `load` function now returns this information)
- Remove `getDocumentInformation` from the `convertUsingJavascript`

resolves #497