### PR TITLE
use load instead of convert

### DIFF
--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -64,9 +64,9 @@ export class AsciidocEngine {
     return { output, document }
   }
 
-  public async load (documentUri: vscode.Uri, source: string): Promise<any> {
+  public async load (documentUri: vscode.Uri): Promise<Asciidoctor.Document> {
     const textDocument = await vscode.workspace.openTextDocument(documentUri)
-    const { document } = await this.getEngine().parseText(source, textDocument)
+    const { document } = this.getEngine().load(textDocument)
     return document
   }
 }

--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -7,6 +7,7 @@ import { AsciidocContributions } from './asciidocExtensions'
 import { Slugifier } from './slugify'
 import { AsciidocParser } from './asciidocParser'
 import { Asciidoctor } from '@asciidoctor/core'
+import { SkinnyTextDocument } from './util/document'
 
 const FrontMatterRegex = /^---\s*[^]*?(-{3}|\.{3})\s*/
 
@@ -64,8 +65,7 @@ export class AsciidocEngine {
     return { output, document }
   }
 
-  public async load (documentUri: vscode.Uri): Promise<Asciidoctor.Document> {
-    const textDocument = await vscode.workspace.openTextDocument(documentUri)
+  public load (textDocument: SkinnyTextDocument): Asciidoctor.Document {
     const { document } = this.getEngine().load(textDocument)
     return document
   }

--- a/src/features/attributeReferenceProvider.ts
+++ b/src/features/attributeReferenceProvider.ts
@@ -6,8 +6,8 @@ export class AttributeReferenceProvider {
   constructor (private readonly extensionUri: vscode.Uri) {
   }
 
-  async provideCompletionItems (textDocument: vscode.TextDocument, position: vscode.Position) {
-    const { document } = await new AsciidocParser(this.extensionUri).parseText(textDocument.getText(), textDocument)
+  provideCompletionItems (textDocument: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] {
+    const { document } = new AsciidocParser(this.extensionUri).load(textDocument)
     const attributes = document.getAttributes()
     const lineText = textDocument.lineAt(position).text
     const prefix = lineText.substring(position.character - 1, position.character)
@@ -23,7 +23,6 @@ export class AttributeReferenceProvider {
       insertText = suffix !== '}' ? `${insertText}}` : insertText
       completionItem.insertText = insertText
       return completionItem
-    }
-    )
+    })
   }
 }

--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -149,7 +149,7 @@ export namespace Import {
       //default filename
       let filename = `${currentDateString}.png`
       let alttext = '' //todo:...
-      const directory = await this.getCurrentImagesDir()
+      const directory = this.getCurrentImagesDir()
 
       // confirm directory is local--asciidoctor allows external URIs. test for
       // protocol (http, ftp, etc) to determine this
@@ -311,7 +311,7 @@ export namespace Import {
      * Reads the _nearest_ `:imagesdir:` attribute that appears _before_ the current selection
      * or cursor location, failing that figures it out from the API by converting the document and reading the attribute
      */
-    static async getCurrentImagesDir () {
+    static getCurrentImagesDir () {
       const text = vscode.window.activeTextEditor.document.getText()
 
       const imagesdir = /^[\t\f]*?:imagesdir:\s+(.+?)\s+$/gim
@@ -331,7 +331,7 @@ export namespace Import {
       if (dir === '') {
         const textDocument = vscode.window.activeTextEditor.document
         const extensionUri = vscode.Uri.file('') // won't be used anyway... needs refactoring!
-        const { document } = await new AsciidocParser(extensionUri).parseText(textDocument.getText(), textDocument)
+        const { document } = new AsciidocParser(extensionUri).load(textDocument)
         dir = document.getAttribute('imagesdir')
       }
 

--- a/src/tableOfContentsProvider.ts
+++ b/src/tableOfContentsProvider.ts
@@ -40,8 +40,8 @@ export class TableOfContentsProvider {
     return toc.find((entry) => entry.slug.equals(slug))
   }
 
-  private async buildToc (textDocument: SkinnyTextDocument): Promise<TocEntry[]> {
-    const asciidocDocument = await this.engine.load(textDocument.uri)
+  private buildToc (textDocument: SkinnyTextDocument): TocEntry[] {
+    const asciidocDocument = this.engine.load(textDocument)
 
     const toc = asciidocDocument
       .findBy({ context: 'section' })

--- a/src/tableOfContentsProvider.ts
+++ b/src/tableOfContentsProvider.ts
@@ -40,20 +40,19 @@ export class TableOfContentsProvider {
     return toc.find((entry) => entry.slug.equals(slug))
   }
 
-  private async buildToc (document: SkinnyTextDocument): Promise<TocEntry[]> {
-    const toc: TocEntry[] = []
-    const adoc = await this.engine.load(document.uri, document.getText())
+  private async buildToc (textDocument: SkinnyTextDocument): Promise<TocEntry[]> {
+    const asciidocDocument = await this.engine.load(textDocument.uri)
 
-    adoc.findBy({ context: 'section' }, function (section) {
-      toc.push({
+    const toc = asciidocDocument
+      .findBy({ context: 'section' })
+      .map((section) => ({
         slug: section.getId(),
         text: section.getTitle(),
         level: section.getLevel(),
         line: section.getLineNumber() - 1,
-        location: new vscode.Location(document.uri,
+        location: new vscode.Location(textDocument.uri,
           new vscode.Position(section.getLineNumber() - 1, 1)),
-      })
-    })
+      }))
 
     // Get full range of section
     return toc.map((entry, startIndex): TocEntry => {
@@ -64,13 +63,13 @@ export class TableOfContentsProvider {
           break
         }
       }
-      const endLine = typeof end === 'number' ? end : document.lineCount - 1
+      const endLine = typeof end === 'number' ? end : textDocument.lineCount - 1
       return {
         ...entry,
-        location: new vscode.Location(document.uri,
+        location: new vscode.Location(textDocument.uri,
           new vscode.Range(
             entry.location.range.start,
-            new vscode.Position(endLine, document.lineAt(endLine).range.end.character))),
+            new vscode.Position(endLine, textDocument.lineAt(endLine).range.end.character))),
       }
     })
   }

--- a/src/tableOfContentsProvider.ts
+++ b/src/tableOfContentsProvider.ts
@@ -46,7 +46,7 @@ export class TableOfContentsProvider {
     const toc = asciidocDocument
       .findBy({ context: 'section' })
       .map((section) => ({
-        slug: section.getId(),
+        slug: new Slug(section.getId()),
         text: section.getTitle(),
         level: section.getLevel(),
         line: section.getLineNumber() - 1,

--- a/src/test/image-paste.test.ts
+++ b/src/test/image-paste.test.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode'
+import assert from 'assert'
+import { Import } from '../image-paste'
+import { InMemoryDocument } from './inMemoryDocument'
+
+const testFileName = vscode.Uri.file('test.adoc')
+
+suite('getCurrentImagesDir', () => {
+  test('Should return blank when the document is blank', () => {
+    assert.strictEqual(Import.Image.getCurrentImagesDir(new InMemoryDocument(testFileName, ''), new vscode.Selection(0, 0, 0, 0)), '')
+  })
+
+  test('Should return imagesdir attribute defined in the AsciiDoc document', () => {
+    const content = `= Document Title
+:imagesdir: /path/to/images
+`
+    const document = new InMemoryDocument(testFileName, content)
+    assert.strictEqual(Import.Image.getCurrentImagesDir(document, new vscode.Selection(0, 0, 0, 0)), '/path/to/images')
+  })
+
+  test('Should return imagesdir depending on active line', () => {
+    const textDocument = new InMemoryDocument(testFileName, `= Document Title
+:imagesdir: /path/to/images
+
+This is a preamble.
+
+== Section Title
+
+:imagesdir: /path/to/assets
+
+:imagesdir: /path/to/img
+`);
+    // document attribute
+    assert.strictEqual(Import.Image.getCurrentImagesDir(textDocument, new vscode.Selection(2, 0, 2, 0)), '/path/to/images')
+    // attribute defined at line 7
+    assert.strictEqual(Import.Image.getCurrentImagesDir(textDocument, new vscode.Selection(8, 0, 8, 0)), '/path/to/assets')
+    // attribute defined at line 9
+    assert.strictEqual(Import.Image.getCurrentImagesDir(textDocument, new vscode.Selection(10, 0, 10, 0)), '/path/to/img')
+  })
+})

--- a/src/test/image-paste.test.ts
+++ b/src/test/image-paste.test.ts
@@ -29,7 +29,7 @@ This is a preamble.
 :imagesdir: /path/to/assets
 
 :imagesdir: /path/to/img
-`);
+`)
     // document attribute
     assert.strictEqual(Import.Image.getCurrentImagesDir(textDocument, new vscode.Selection(2, 0, 2, 0)), '/path/to/images')
     // attribute defined at line 7

--- a/src/test/inMemoryDocument.ts
+++ b/src/test/inMemoryDocument.ts
@@ -40,8 +40,11 @@ export class InMemoryDocument implements vscode.TextDocument {
     }
   }
 
-  offsetAt (_position: vscode.Position): never {
-    throw new Error('Method not implemented.')
+  offsetAt (position: vscode.Position): number {
+    let lines = this._contents.split('\n')
+    lines = lines.splice(0, position.line + 1)
+    lines[lines.length - 1] = lines[lines.length - 1].substring(0, position.character)
+    return lines.join('\n').split('').length
   }
 
   positionAt (offset: number): vscode.Position {


### PR DESCRIPTION
#### What I Did

- Add tests on `Import.Image.getCurrentImagesDir`
- Change the signature of `getCurrentImagesDir` to make it easier to test
- Fix the regular expression that checks if the string starts with a protocol: `/^(?:[a-z]+:)?\/\//i` (remote)
- Use the `load` function in `attributeReferenceProvider.ts`, `tableOfContentsProvider.ts` and `image-paste.ts` since we only need an Asciidoctor.Document (instead of the parse/convert)


In a following pull request, I will probably remove a layer of indirection since we don't really need both `AsciidocEngine` and `AsciidocParser`.
In other words, `AsciidocEngine` has little to no value.