### PR TITLE
Fix format of paste image default filename

### DIFF
--- a/src/image-paste.ts
+++ b/src/image-paste.ts
@@ -150,8 +150,7 @@ export namespace Import {
 
       const currentDateString = new Date()
         .toISOString()
-        .replace(':', '-')
-        .replace('.', '-')
+        .replace(/[:.]/g, '-')
       // default filename
       let filename = `${currentDateString}.png`
       let alttext = '' //todo:...


### PR DESCRIPTION
There are two colons in ISO date format, only the first one was replaced, causing a %3A in the URI name.