### PR TITLE
Fixes for opening links to local files in preview window

### DIFF
--- a/src/features/preview.ts
+++ b/src/features/preview.ts
@@ -442,7 +442,7 @@ export class AsciidocPreview {
       // Handle any normalized file paths
       hrefPath = vscode.Uri.parse(hrefPath.replace('/file', '')).fsPath
     }
-    const openLinks = this.config.get<string>('preview.openAsciidocLinks', 'inPreview')
+    const openLinks = this.config.get<string>('preview.openAsciiDocLinks', 'inPreview')
     if (openLinks === 'inPreview') {
       const asciidocLink = await resolveLinkToAsciidocFile(hrefPath)
       if (asciidocLink) {
@@ -451,7 +451,7 @@ export class AsciidocPreview {
       }
     }
 
-    vscode.commands.executeCommand('_asciidoc.openDocumentLink', { path, fragment })
+    vscode.commands.executeCommand('_asciidoc.openDocumentLink', { path: hrefPath, fragment })
   }
 
   private async onCacheImageSizes (imageInfo: { id: string, width: number, height: number }[]) {


### PR DESCRIPTION
This commit adds fixes so the following works:
- Clicking on a link to a local non AsciiDoc file in the preview window opens the file in the editor.
- Clicking on a link to a local AsciiDoc file in the preview window opens the file in the editor if the option `asciidoc.preview.openAsciiDocLinks` is set to any string different from `inPreview`, if set to `inPreview` it opens the file in the preview window.

These fixes were discussed here: https://github.com/asciidoctor/asciidoctor-vscode/issues/435#issuecomment-1149237428