### PR TITLE
fixed for localization issue

### DIFF
--- a/i18n/fra/src/security.i18n.json
+++ b/i18n/fra/src/security.i18n.json
@@ -9,12 +9,11 @@
   "security.disable.description": "Autorise le chargement de l'ensemble des contenus ainsi que l'exécution des scripts. Pas recommandé.",
   "security.enableSecurityWarning.title": "Activer les alertes de sécurité de la prévisualisation sur cet espace de travail",
   "security.disableSecurityWarning.title": "Désactiver les alertes de sécurité de la prévisualisation sur cet espace de travail",
-  "security.toggleSecurityWarning.title": "À noter que cela n'affecte pas le niveau de securité configuré.",
   "security.showPreviewSecuritySelector.title": "Sélectionner le niveau de securité adapté aux prévisualisations des documents AsciiDoc sur cet espace de travail.",
   "security.restrictAsciidoctorExtensionsAuthors.title": "Non approuvé",
   "security.restrictAsciidoctorExtensionsAuthors.description": "Désactive l'exécution du code des extensions Asciidoctor.js.",
   "security.trustAsciidoctorExtensionsAuthors.title": "Approuvé",
   "security.trustAsciidoctorExtensionsAuthors.description": "Autorise l'exécution du code des extensions Asciidoctor.js.",
   "security.asciidoctorExtensionsTrustModeSelector.title": "Séléctionner le niveau de confiance adapté aux extensions Asciidoctor.js présentes sur cet espace de travail.",
-  "security.toggleSecurityWarning.description": "Please note that it does not affect the content security level."
+  "security.toggleSecurityWarning.description": "À noter que cela n'affecte pas le niveau de securité configuré."
 }

--- a/i18n/fra/src/security.i18n.json
+++ b/i18n/fra/src/security.i18n.json
@@ -15,5 +15,6 @@
   "security.restrictAsciidoctorExtensionsAuthors.description": "Désactive l'exécution du code des extensions Asciidoctor.js.",
   "security.trustAsciidoctorExtensionsAuthors.title": "Approuvé",
   "security.trustAsciidoctorExtensionsAuthors.description": "Autorise l'exécution du code des extensions Asciidoctor.js.",
-  "security.asciidoctorExtensionsTrustModeSelector.title": "Séléctionner le niveau de confiance adapté aux extensions Asciidoctor.js présentes sur cet espace de travail."
+  "security.asciidoctorExtensionsTrustModeSelector.title": "Séléctionner le niveau de confiance adapté aux extensions Asciidoctor.js présentes sur cet espace de travail.",
+  "security.toggleSecurityWarning.description": "Please note that it does not affect the content security level."
 }

--- a/i18n/jpn/src/security.i18n.json
+++ b/i18n/jpn/src/security.i18n.json
@@ -15,5 +15,6 @@
   "security.restrictAsciidoctorExtensionsAuthors.description": "Asciidoctor.js拡張を無効にして、コードの実行を抑止します。",
   "security.trustAsciidoctorExtensionsAuthors.title": "信頼済み",
   "security.trustAsciidoctorExtensionsAuthors.description": "Asciidoctor.js拡張を有効化して、コードの実行を許可します。",
-  "security.asciidoctorExtensionsTrustModeSelector.title": "Asciidoctor.js拡張の信頼モードの選択"
+  "security.asciidoctorExtensionsTrustModeSelector.title": "Asciidoctor.js拡張の信頼モードの選択",
+  "security.toggleSecurityWarning.description": "コンテンツのセキュリティレベルには影響しませんので、ご注意ください。"
 }

--- a/src/asciidoctorWebViewConverter.ts
+++ b/src/asciidoctorWebViewConverter.ts
@@ -1,11 +1,13 @@
 import vscode from 'vscode'
-import { localize } from './i18n'
 import { dirname, isAbsolute, join } from './util/path'
 import { AsciidocPreviewSecurityLevel, ContentSecurityPolicyArbiter } from './security'
 import { AsciidocPreviewConfiguration, AsciidocPreviewConfigurationManager } from './features/previewConfig'
 import { WebviewResourceProvider } from './util/resources'
 import { Asciidoctor } from '@asciidoctor/core'
 import { SkinnyTextDocument } from './util/document'
+import * as nls from 'vscode-nls'
+
+const localize = nls.loadMessageBundle()
 
 const { Opal } = require('asciidoctor-opal-runtime')
 const processor = require('@asciidoctor/core')()

--- a/src/features/documentLinkProvider.ts
+++ b/src/features/documentLinkProvider.ts
@@ -2,13 +2,15 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../i18n'
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { OpenDocumentLinkCommand } from '../commands/openDocumentLink'
 import { getUriForLinkWithKnownExternalScheme } from '../util/links'
 import { similarArrayMatch } from '../similarArrayMatch'
 import { isSchemeBlacklisted } from '../linkSanitizer'
+import * as nls from 'vscode-nls'
+
+const localize = nls.loadMessageBundle()
 
 export interface AsciidoctorLinkRegexes {
   [key: string]: RegExp

--- a/src/features/preview.ts
+++ b/src/features/preview.ts
@@ -2,7 +2,6 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from '../i18n'
 import * as vscode from 'vscode'
 import * as path from 'path'
 
@@ -15,6 +14,9 @@ import { AsciidocPreviewConfigurationManager } from './previewConfig'
 import { AsciidocContributions } from '../asciidocExtensions'
 import { isAsciidocFile } from '../util/file'
 import { resolveLinkToAsciidocFile } from '../commands/openDocumentLink'
+import * as nls from 'vscode-nls'
+
+const localize = nls.loadMessageBundle()
 
 export class AsciidocPreview extends Disposable implements WebviewResourceProvider {
   public static viewType = 'asciidoc.preview'

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,5 +2,3 @@ import * as nls from 'vscode-nls'
 
 // configure once
 nls.config({ messageFormat: nls.MessageFormat.file })()
-
-export const localize = nls.loadMessageBundle()

--- a/src/security.ts
+++ b/src/security.ts
@@ -2,9 +2,11 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from './i18n'
 import * as vscode from 'vscode'
 import { AsciidocPreviewManager } from './features/previewManager'
+import * as nls from 'vscode-nls'
+
+const localize = nls.loadMessageBundle()
 
 export const enum AsciidocPreviewSecurityLevel {
   Strict = 0,


### PR DESCRIPTION
Hi, @Mogztter .

I found a issue that relate a localization .
Localizations didn't work except config's titles or descriptions.

vscode-nls-dev has procedure which is following...
1. Search nls.loadMessageBundle() from js files
2. Create xxx.nls.json by js file name which is found in "1.".
3. Create *.nls.[jp/fr].json from a i18n directory and "2.".

In current master branch, only i18n.ts has nls.loadMessageBundle().
I think that it is a bad implementation. 

Can you check it?
And, please translate English message in i18n/fra/src/security.i18n.json.