### PR TITLE
add support for custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The preview supports setting AsciiDoc attributes through the `asciidoc.preview.a
 
 By default, the preview uses VS Code editor theme (`workbench.colorTheme`).
 To use Asciidoctor default style set the `asciidoc.preview.useEditorStyle` setting to `false`.
-It is also possible to set your own preview stylesheet with the `asciidoc.preview.style` setting.<br/>
+It is possible to set your own preview stylesheet with the `asciidoc.preview.style` setting.<br/>
+It is also possible to define custom templates with the `asciidoc.preview.templates` setting.<br/>
 (See more details under [Extension Settings](#extension-settings))
 
 ### Export as PDF

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@asciidoctor/docbook-converter": "2.0.0",
 				"@orcid/bibtex-parse-js": "0.0.25",
 				"asciidoctor-kroki": "0.15.4",
+				"pug": "^3.0.2",
 				"uuid": "8.3.2",
 				"vscode-nls": "5.0.0",
 				"vscode-uri": "3.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
 				"@asciidoctor/docbook-converter": "2.0.0",
 				"@orcid/bibtex-parse-js": "0.0.25",
 				"asciidoctor-kroki": "0.15.4",
-				"pug": "^3.0.2",
 				"uuid": "8.3.2",
 				"vscode-nls": "5.0.0",
 				"vscode-uri": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -385,9 +385,13 @@
 						"scope": "resource"
 					},
 					"asciidoc.preview.templates": {
-						"type": "string",
+						"type": "array",
 						"default": "",
 						"markdownDescription": "%asciidoc.preview.templates.desc%",
+						"items": {
+							"type": "string"
+						  },
+						  "uniqueItems": false,
 						"scope": "resource"
 					},
 					"asciidoc.use_kroki": {
@@ -630,7 +634,6 @@
 		"@asciidoctor/docbook-converter": "2.0.0",
 		"@orcid/bibtex-parse-js": "0.0.25",
 		"asciidoctor-kroki": "0.15.4",
-		"pug": "^3.0.2",
 		"uuid": "8.3.2",
 		"vscode-nls": "5.0.0",
 		"vscode-uri": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -384,6 +384,12 @@
 						],
 						"scope": "resource"
 					},
+					"asciidoc.preview.templates": {
+						"type": "string",
+						"default": "",
+						"markdownDescription": "%asciidoc.preview.templates.desc%",
+						"scope": "resource"
+					},
 					"asciidoc.use_kroki": {
 						"type": "boolean",
 						"default": false,
@@ -624,9 +630,10 @@
 		"@asciidoctor/docbook-converter": "2.0.0",
 		"@orcid/bibtex-parse-js": "0.0.25",
 		"asciidoctor-kroki": "0.15.4",
+		"pug": "^3.0.2",
 		"uuid": "8.3.2",
 		"vscode-nls": "5.0.0",
-		"vscode-uri": "3.0.3"
+		"vscode-uri": "^3.0.3"
 	},
 	"__metadata": {
 		"id": "c1309cc2-f420-46a3-b2be-ca04f4d9e51b",

--- a/package.nls.json
+++ b/package.nls.json
@@ -30,6 +30,7 @@
 	"asciidoc.preview.openLinksToAsciidocFiles.desc": "Controls how links to other AsciiDoc files in the preview should be opened.",
 	"asciidoc.preview.openLinksToAsciidocFiles.inPreview": "Try to open links in the editor",
 	"asciidoc.preview.openLinksToAsciidocFiles.inEditor": "Try to open links in the preview",
+	"asciidoc.preview.templates.desc": "An URL or a local path to custom templates to use from the preview. Relative paths are interpreted relative to the folder open in the Explorer. If there is no open folder, they are interpreted relative to the location of the AsciiDoc file. All `\\` need to be written as `\\\\`.",
 
 	"asciidoc.pdf.title": "PDF",
 	"asciidoc.pdf.engine.desc": "Controls the PDF engine used to export as PDF.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -30,7 +30,7 @@
 	"asciidoc.preview.openLinksToAsciidocFiles.desc": "Controls how links to other AsciiDoc files in the preview should be opened.",
 	"asciidoc.preview.openLinksToAsciidocFiles.inPreview": "Try to open links in the editor",
 	"asciidoc.preview.openLinksToAsciidocFiles.inEditor": "Try to open links in the preview",
-	"asciidoc.preview.templates.desc": "An URL or a local path to custom templates to use from the preview. Relative paths are interpreted relative to the folder open in the Explorer. If there is no open folder, they are interpreted relative to the location of the AsciiDoc file. All `\\` need to be written as `\\\\`.",
+	"asciidoc.preview.templates.desc": "List of local paths to custom templates to use from the preview. Relative paths are interpreted relative to the folder open in the Explorer. If there is no open folder, they are interpreted relative to the location of the AsciiDoc file. All `\\` need to be written as `\\\\`.",
 
 	"asciidoc.pdf.title": "PDF",
 	"asciidoc.pdf.engine.desc": "Controls the PDF engine used to export as PDF.",

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -168,7 +168,7 @@ export class AsciidocParser {
       ...(baseDir && { base_dir: baseDir }),
     }
     if (templateDirs.length !== 0) {
-      options["template_dirs"] = templateDirs
+      options.template_dirs = templateDirs
     }
 
     try {
@@ -270,7 +270,7 @@ export class AsciidocParser {
    * @private
    */
   private getTemplateDirs () {
-    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get<String []>('templates',[])
+    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get<String []>('templates', [])
     return templatesDir
   }
 

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -270,7 +270,7 @@ export class AsciidocParser {
    * @private
    */
   private getTemplateDirs () {
-    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get<String []>('templates', [])
+    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get<string[]>('templates', [])
     return templatesDir
   }
 

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -157,6 +157,7 @@ export class AsciidocParser {
     attributes['env-vscode'] = ''
 
     const baseDir = AsciidocParser.getBaseDir(doc.fileName)
+    const templateDir = this.getTemplateDir()
     const options: { [key: string]: any } = {
       attributes,
       backend: 'webview-html5',
@@ -164,6 +165,7 @@ export class AsciidocParser {
       header_footer: true,
       safe: 'unsafe',
       sourcemap: true,
+      template_dirs: [templateDir],
       ...(baseDir && { base_dir: baseDir }),
     }
 
@@ -259,6 +261,15 @@ export class AsciidocParser {
     return useWorkspaceAsBaseDir && typeof vscode.workspace.rootPath !== 'undefined'
       ? vscode.workspace.rootPath
       : documentPath
+  }
+
+  /**
+   * Get user defined templates directory from configuration.
+   * @private
+   */
+  private getTemplateDir () {
+    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get('templates')
+    return templatesDir
   }
 
   private async confirmAsciidoctorExtensionsTrusted (): Promise<boolean> {

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -157,7 +157,7 @@ export class AsciidocParser {
     attributes['env-vscode'] = ''
 
     const baseDir = AsciidocParser.getBaseDir(doc.fileName)
-    const templateDir = this.getTemplateDir()
+    const templateDirs = this.getTemplateDirs()
     const options: { [key: string]: any } = {
       attributes,
       backend: 'webview-html5',
@@ -165,8 +165,10 @@ export class AsciidocParser {
       header_footer: true,
       safe: 'unsafe',
       sourcemap: true,
-      template_dirs: [templateDir],
       ...(baseDir && { base_dir: baseDir }),
+    }
+    if (templateDirs.length !== 0) {
+      options["template_dirs"] = templateDirs
     }
 
     try {
@@ -264,11 +266,11 @@ export class AsciidocParser {
   }
 
   /**
-   * Get user defined templates directory from configuration.
+   * Get user defined template directories from configuration.
    * @private
    */
-  private getTemplateDir () {
-    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get('templates')
+  private getTemplateDirs () {
+    const templatesDir = vscode.workspace.getConfiguration('asciidoc.preview', null).get<String []>('templates',[])
     return templatesDir
   }
 

--- a/src/asciidoctorWebViewConverter.ts
+++ b/src/asciidoctorWebViewConverter.ts
@@ -88,6 +88,7 @@ export class AsciidoctorWebViewConverter {
   config: AsciidocPreviewConfiguration
   initialData: { [key: string]: any }
   state: object
+  backendTraits: { supports_templates: boolean }
 
   constructor (
     private readonly textDocument: SkinnyTextDocument,
@@ -116,6 +117,9 @@ export class AsciidoctorWebViewConverter {
       disableSecurityWarnings: cspArbiter.shouldDisableSecurityWarnings(),
     }
     this.state = state || {}
+    this.backendTraits = {
+      supports_templates: true
+    }
   }
 
   /**

--- a/src/asciidoctorWebViewConverter.ts
+++ b/src/asciidoctorWebViewConverter.ts
@@ -118,7 +118,7 @@ export class AsciidoctorWebViewConverter {
     }
     this.state = state || {}
     this.backendTraits = {
-      supports_templates: true
+      supports_templates: true,
     }
   }
 

--- a/src/features/previewConfig.ts
+++ b/src/features/previewConfig.ts
@@ -24,7 +24,7 @@ export class AsciidocPreviewConfiguration {
   public readonly refreshInterval: number
   public readonly useEditorStylesheet: boolean
   public readonly previewStyle: string
-  public readonly previewTemplates: string
+  public readonly previewTemplates: string[]
 
   private constructor (resource: vscode.Uri) {
     const editorConfig = vscode.workspace.getConfiguration('editor', resource)
@@ -51,7 +51,7 @@ export class AsciidocPreviewConfiguration {
     this.styles = asciidocConfig.get<string[]>('styles', []) // REMIND: unused, we should either use it or remove it!
     this.useEditorStylesheet = asciidocConfig.get<boolean>('preview.useEditorStyle', false)
     this.previewStyle = asciidocConfig.get<string>('preview.style', '')
-    this.previewTemplates = asciidocConfig.get<string>('preview.templates', '')
+    this.previewTemplates = asciidocConfig.get<string[]>('preview.templates', [])
     this.refreshInterval = Math.max(0.6, +asciidocConfig.get<number>('preview.refreshInterval', NaN))
   }
 

--- a/src/features/previewConfig.ts
+++ b/src/features/previewConfig.ts
@@ -24,6 +24,7 @@ export class AsciidocPreviewConfiguration {
   public readonly refreshInterval: number
   public readonly useEditorStylesheet: boolean
   public readonly previewStyle: string
+  public readonly previewTemplates: string
 
   private constructor (resource: vscode.Uri) {
     const editorConfig = vscode.workspace.getConfiguration('editor', resource)
@@ -50,6 +51,7 @@ export class AsciidocPreviewConfiguration {
     this.styles = asciidocConfig.get<string[]>('styles', []) // REMIND: unused, we should either use it or remove it!
     this.useEditorStylesheet = asciidocConfig.get<boolean>('preview.useEditorStyle', false)
     this.previewStyle = asciidocConfig.get<string>('preview.style', '')
+    this.previewTemplates = asciidocConfig.get<string>('preview.templates', '')
     this.refreshInterval = Math.max(0.6, +asciidocConfig.get<number>('preview.refreshInterval', NaN))
   }
 


### PR DESCRIPTION
This MR allows user-defined custom templates to be provided at conversion time. 
To use a pug template:
   * On a terminal,  $  npm i pug
   * In Settings -> AsciiDoc -> Open Preview,  define path to pub templates 

   