### PR TITLE
Search path for included files

### DIFF
--- a/src/providers/asciidoc.provider.ts
+++ b/src/providers/asciidoc.provider.ts
@@ -50,7 +50,6 @@ async function provide (
     }
   }
 
-  const workspace = vscode.workspace.getWorkspaceFolder(context.document.uri)
   const documentPath = context.document.uri.fsPath
   const rootPath = documentPath.substr(0, documentPath.lastIndexOf('/'))
   const searchPath = getPathOfFolderToLookupFiles(

--- a/src/providers/asciidoc.provider.ts
+++ b/src/providers/asciidoc.provider.ts
@@ -87,6 +87,7 @@ async function provide (
 
   return [
     levelUpCompletionItem,
+    ...variablePathSubstitutions,
     ...items.map((child) => {
       const result = createPathCompletionItem(child)
       result.insertText = result.kind === vscode.CompletionItemKind.File ? child.file + '[]' : child.file
@@ -99,7 +100,6 @@ async function provide (
       }
       return result
     }),
-    ...variablePathSubstitutions,
   ]
 }
 

--- a/src/providers/asciidoc.provider.ts
+++ b/src/providers/asciidoc.provider.ts
@@ -51,7 +51,8 @@ async function provide (
   }
 
   const workspace = vscode.workspace.getWorkspaceFolder(context.document.uri)
-  const rootPath = workspace?.uri.fsPath
+  const documentPath = context.document.uri.fsPath
+  const rootPath = documentPath.substr(0, documentPath.lastIndexOf('/'))
   const searchPath = getPathOfFolderToLookupFiles(
     context.document.uri.fsPath,
     path.join(rootPath, entryDir)
@@ -86,7 +87,6 @@ async function provide (
 
   return [
     levelUpCompletionItem,
-    ...variablePathSubstitutions,
     ...items.map((child) => {
       const result = createPathCompletionItem(child)
       result.insertText = result.kind === vscode.CompletionItemKind.File ? child.file + '[]' : child.file
@@ -99,6 +99,7 @@ async function provide (
       }
       return result
     }),
+    ...variablePathSubstitutions,
   ]
 }
 


### PR DESCRIPTION
I adjusted the search path for included files, in case that the current file is not at the root of the workspace.

I really would like to see that the completions for document attributes are either hidden or shown towards the end of the list, at least they (most of them) do not make much sense in the context of an include. I tried to figure that out, but I could not find the place where the AsciidocProvider gets registered. If I could get some directions here, I'll try to figure that out.

![image](https://user-images.githubusercontent.com/1238044/184531799-f80ad0d6-7494-47d8-9d17-fd72a25fce50.png)
