### PR TITLE
provide sorttext on include suggestions

### DIFF
--- a/src/features/attributeReferenceProvider.ts
+++ b/src/features/attributeReferenceProvider.ts
@@ -19,6 +19,7 @@ export class AttributeReferenceProvider {
       insertText = prefix !== '{' ? `{${insertText}` : insertText
       insertText = suffix !== '}' ? `${insertText}}` : insertText
       completionItem.insertText = insertText
+      completionItem.sortText = `20_${key}`
       return completionItem
     })
   }

--- a/src/providers/asciidoc.provider.ts
+++ b/src/providers/asciidoc.provider.ts
@@ -64,7 +64,7 @@ async function provide (
   const levelUpCompletionItem: vscode.CompletionItem = {
     label: '..',
     kind: vscode.CompletionItemKind.Folder,
-    sortText: '..',
+    sortText: '10_..',
   }
   const globalVariableDefinitions = documentText.match(/:\S+:.*/g)
 
@@ -78,7 +78,7 @@ async function provide (
       return {
         label: `{${label}}`,
         kind: vscode.CompletionItemKind.Variable,
-        sortText: `a_${label}`,
+        sortText: `10_${label}`,
         insertText: `{${label}${doAutoCloseBrackets ? '' : '}'}`, // } curly bracket will be closed automatically by default
       }
     })
@@ -108,6 +108,6 @@ function createPathCompletionItem (
   return {
     label: fileInfo.file,
     kind: fileInfo.isFile ? vscode.CompletionItemKind.File : vscode.CompletionItemKind.Folder,
-    sortText: fileInfo.file,
+    sortText: `10_${fileInfo.file}`,
   }
 }


### PR DESCRIPTION
https://github.com/asciidoctor/asciidoctor-vscode/issues/621

This PR makes files show up in front of attributes on include suggestions. I tried to keep it as simple as possible.

Do you see any cross-side-effects on other scenarios when the `AttributeReferenceProvider' has a sortText?