### PR TITLE
Use VS Code color theme for sidebar Table of Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix the logic that detects if `asciidoctor-pdf` and/or `bundler` are available in the `PATH`
 - fix base directory when exporting to PDF on Windows (#593)
 - fix localization generation by @YoshihideShirai (#594)
+- fix Table Of Content sidebar color not aligned with the active theme by @apupier (#340)
 - fix typo Recomendations -> Recommendations in snippets by @apupier
 
 ## 3.0.0 "pre-release" (2022-07-06) - @mogztter

--- a/media/asciidoctor-editor.css
+++ b/media/asciidoctor-editor.css
@@ -978,8 +978,8 @@ body.toc2 #header>h1:nth-last-child(2) {
   #toc.toc2 {
     margin-top: 0 !important;
     /* DISABLED background: #f8f8f7; */
-    background: white; /* TODO: fix transparent toc background */
-    color: rgba(0, 0, 0, .8); /* TODO: fix transparent toc background */
+    background: var(--vscode-editor-background);
+    color: var(--vscode-editor-color);
     position: fixed;
     width: 15em;
     left: 0;


### PR DESCRIPTION
it prevents having a white background when using a dark theme. Also using the font from the theme to avoid having black text on black background when using Dark theme

fixes #340

State after this Pull Request:
![image](https://user-images.githubusercontent.com/1105127/189350142-d8b816d7-7f54-472e-add6-ea81b4f2db82.png)

