### PR TITLE
Support .asciidoctorconfig at root of the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- support .asciidoctorconfig at root of the workspace by @apupier (#380)
+
 ### Bug fixes
 
 - fix the logic that detects if `asciidoctor-pdf` and/or `bundler` are available in the `PATH`

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Here's an example of how to use the [asciidoctor-emoji](https://github.com/mogzt
 
 ![Asciidoctor.js Emoji extension enabled!](images/asciidoctor-vscode-emoji-ext.png)
 
+### Asciidoctor Config File
+
+To provide a common set of variables when rendering the preview, the extension reads an `.asciidoctorconfig` configuration file. Use this to optimize the preview when the project contains a document that is split out to multiple include-files.
+
+It is inspired by the implementation provided in [IntelliJ AsciiDoc Plugin](https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/asciidoctorconfig-file.html) and reused in [Eclipse AsciiDoc plugin](https://github.com/de-jcup/eclipse-asciidoctor-editor/wiki/Asciidoctor-configfiles).
+
+The current scope is limited to an `.asciidoctorconfig` configuration file provided at the root of the workspace.
+
 ## Extension Settings
 
 This extension contributes the following settings:

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import * as fs from 'fs'
 import * as path from 'path'
 import { AsciidoctorWebViewConverter } from './asciidoctorWebViewConverter'
 import { Asciidoctor } from '@asciidoctor/core'
@@ -8,6 +7,7 @@ import { AsciidocPreviewConfigurationManager } from './features/previewConfig'
 import { SkinnyTextDocument } from './util/document'
 import { IncludeItems } from './asciidoctorFindIncludeProcessor'
 import { AsciidocContributionProvider } from './asciidocExtensions'
+import { getAsciidoctorConfigContent } from './features/asciidoctorConfig'
 
 const asciidoctorFindIncludeProcessor = require('./asciidoctorFindIncludeProcessor')
 
@@ -26,12 +26,25 @@ const previewConfigurationManager = new AsciidocPreviewConfigurationManager()
 export class AsciidocParser {
   private stylesdir: string
   private apsArbiter: AsciidoctorExtensionsSecurityPolicyArbiter
+  public prependExtension: Asciidoctor.Extensions.PreprocessorKlass
 
   constructor (
     readonly contributionProvider: AsciidocContributionProvider,
     readonly aspArbiter: AsciidoctorExtensionsSecurityPolicyArbiter = null,
     private errorCollection: vscode.DiagnosticCollection = null
   ) {
+    this.prependExtension = processor.Extensions.createPreprocessor('PreprendConfigPreprocessorExtension', {
+      postConstruct: function () {
+        this.asciidoctorConfigContent = ''
+      },
+      process: function (doc, reader) {
+        if (this.asciidoctorConfigContent.length > 0) {
+          // otherwise an empty line at the beginning breaks level 0 detection
+          reader.pushInclude(this.asciidoctorConfigContent, undefined, undefined, 1, {})
+        }
+      },
+    }).$new()
+
     // Asciidoctor.js in the browser environment works with URIs however for desktop clients
     // the stylesdir attribute is expected to look like a file system path (especially on Windows)
     if (process.env.BROWSER_ENV) {
@@ -173,16 +186,9 @@ export class AsciidocParser {
     }
 
     try {
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri)
-      if (workspaceFolder !== undefined) {
-        const asciiDoctorConfig = vscode.Uri.joinPath(workspaceFolder.uri, '.asciidoctorconfig')
-        if (fs.existsSync(asciiDoctorConfig.fsPath)) {
-          const asciiDoctorConfigContent = await vscode.workspace.fs.readFile(asciiDoctorConfig)
-          text =
-            ':asciidoctorconfigdir: ' + asciiDoctorConfig.fsPath + '\n\n' +
-            asciiDoctorConfigContent + '\n\n' +
-            text
-        }
+      const asciidoctorConfigContent = await getAsciidoctorConfigContent(doc.uri)
+      if (asciidoctorConfigContent !== undefined) {
+        (this.prependExtension as any).asciidoctorConfigContent = asciidoctorConfigContent
       }
       const document = processor.load(text, options)
       const blocksWithLineNumber = document.findBy(function (b) {
@@ -304,6 +310,7 @@ export class AsciidocParser {
       const kroki = require('asciidoctor-kroki')
       kroki.register(registry)
     }
+    registry.preprocessor(this.prependExtension)
     await this.registerExtensionsInWorkspace(registry)
   }
 

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
 import * as path from 'path'
 import { AsciidoctorWebViewConverter } from './asciidoctorWebViewConverter'
 import { Asciidoctor } from '@asciidoctor/core'
@@ -172,6 +173,17 @@ export class AsciidocParser {
     }
 
     try {
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(doc.uri)
+      if (workspaceFolder !== undefined) {
+        const asciiDoctorConfig = vscode.Uri.joinPath(workspaceFolder.uri, '.asciidoctorconfig')
+        if (fs.existsSync(asciiDoctorConfig.fsPath)) {
+          const asciiDoctorConfigContent = await vscode.workspace.fs.readFile(asciiDoctorConfig)
+          text =
+            ':asciidoctorconfigdir: ' + asciiDoctorConfig.fsPath + '\n\n' +
+            asciiDoctorConfigContent + '\n\n' +
+            text
+        }
+      }
       const document = processor.load(text, options)
       const blocksWithLineNumber = document.findBy(function (b) {
         return typeof b.getLineNumber() !== 'undefined'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,8 @@ import { AntoraSupportManager } from './features/antora/antoraSupport'
 import { DropImageIntoEditorProvider } from './features/dropIntoEditor'
 
 export function activate (context: vscode.ExtensionContext) {
+  // Set context as a global as some tests depend on it
+  (global as any).testExtensionContext = context
   const contributionProvider = getAsciidocExtensionContributions(context)
 
   const cspArbiter = new ExtensionContentSecurityPolicyArbiter(context.globalState, context.workspaceState)

--- a/src/features/asciidoctorConfig.ts
+++ b/src/features/asciidoctorConfig.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode'
+
+async function exists (uri: vscode.Uri) {
+  try {
+    await vscode.workspace.fs.stat(uri)
+    return true
+  } catch (err) {
+    if (err instanceof vscode.FileSystemError.FileNotFound) {
+      return false
+    }
+    throw err
+  }
+}
+
+export async function getAsciidoctorConfigContent (documentUri: vscode.Uri): Promise<String | undefined> {
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri)
+  if (workspaceFolder === undefined) {
+    return undefined
+  }
+  const asciidoctorConfigUri = vscode.Uri.joinPath(workspaceFolder.uri, '.asciidoctorconfig')
+  if (await exists(asciidoctorConfigUri)) {
+    const asciidoctorConfigContent = new TextDecoder().decode(await vscode.workspace.fs.readFile(asciidoctorConfigUri))
+    return `${asciidoctorConfigContent.trim()}\n\n`
+  }
+}

--- a/src/test/asciidoctorconfig.test.ts
+++ b/src/test/asciidoctorconfig.test.ts
@@ -2,21 +2,60 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert'
-import * as vscode from 'vscode'
 import 'mocha'
 
-import { InMemoryDocument } from './inMemoryDocument'
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import { AsciidocParser } from '../asciidocParser'
+import { AsciidocContributionProvider, AsciidocContributions } from '../asciidocExtensions'
+import { AsciidocPreview } from '../features/preview'
+import { AsciidoctorExtensionsSecurityPolicyArbiter } from '../security'
 
-const testFileName = vscode.Uri.file('test.md')
+class EmptyAsciidocContributions implements AsciidocContributions {
+  readonly previewScripts = []
+  readonly previewStyles = []
+  readonly previewResourceRoots = []
+}
+
+class AsciidocContributionProviderTest implements AsciidocContributionProvider {
+  readonly extensionUri
+
+  constructor (extensionUri: vscode.Uri) {
+    this.extensionUri = extensionUri
+  }
+
+  onContributionsChanged: vscode.Event<this>
+
+  readonly contributions = new EmptyAsciidocContributions()
+
+  dispose () {
+    // noop
+  }
+}
 
 suite('asciidoc.Asciidoctorconfig', () => {
-  test('Pick up config from root workspace folder', () => {
-    const doc = new InMemoryDocument(testFileName, '[my-var]')
+  let extensionContext: vscode.ExtensionContext
+  suiteSetup(async () => {
+    // Trigger extension activation and grab the context as some tests depend on it
+    await vscode.extensions.getExtension('vscode.vscode-api-tests')?.activate()
+    extensionContext = (global as any).testExtensionContext
+  })
 
-    // TODO: find how to have the rendered html
-
-    // TODO: assert that rendered document contains `variable coming from .asciictorconfig file placed at root of the workspace`
-    assert.fail(`To check the content of a rendered ${doc.getText}`)
+  test('Pick up config from root workspace folder', async () => {
+    const webview = vscode.window.createWebviewPanel(
+      AsciidocPreview.viewType,
+      'Test',
+      vscode.ViewColumn.One
+    )
+    try {
+      const root = vscode.workspace.workspaceFolders[0].uri.fsPath
+      const file = await vscode.workspace.openTextDocument(vscode.Uri.file(`${root}/attributes.adoc`))
+      // eslint-disable-next-line max-len
+      const asciidocParser = new AsciidocParser(new AsciidocContributionProviderTest(extensionContext.extensionUri), new AsciidoctorExtensionsSecurityPolicyArbiter(extensionContext))
+      const { html } = await asciidocParser.convertUsingJavascript(file.getText(), file, extensionContext, webview)
+      assert.strictEqual(html.includes('<h1>Asciidoctor VS Code Extension</h1>'), true, '{application-name} should be substituted by the value defined in .asciidoctorconfig')
+    } finally {
+      webview.dispose()
+    }
   })
 })

--- a/src/test/asciidoctorconfig.test.ts
+++ b/src/test/asciidoctorconfig.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+  *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import 'mocha'
+
+import { InMemoryDocument } from './inMemoryDocument'
+
+const testFileName = vscode.Uri.file('test.md')
+
+suite('asciidoc.Asciidoctorconfig', () => {
+  test('Pick up config from root workspace folder', () => {
+    const doc = new InMemoryDocument(testFileName, '[my-var]')
+
+    // TODO: find how to have the rendered html
+
+    // TODO: assert that rendered document contains `variable coming from .asciictorconfig file placed at root of the workspace`
+    assert.fail(`To check the content of a rendered ${doc.getText}`)
+  })
+})

--- a/test-workspace/.asciidoctorconfig
+++ b/test-workspace/.asciidoctorconfig
@@ -1,0 +1,1 @@
+:my-var: variable coming from .asciictorconfig file placed at root of the workspace

--- a/test-workspace/.asciidoctorconfig
+++ b/test-workspace/.asciidoctorconfig
@@ -1,1 +1,1 @@
-:my-var: variable coming from .asciictorconfig file placed at root of the workspace
+:application-name: Asciidoctor VS Code Extension

--- a/test-workspace/attributes.adoc
+++ b/test-workspace/attributes.adoc
@@ -1,0 +1,1 @@
+= {application-name}


### PR DESCRIPTION
part of #380

![demo asciidortorconfigAtRootWorkspaceFolder](https://user-images.githubusercontent.com/1105127/189379138-1ee49818-341e-4453-9687-7793a7705765.gif)

TODO for this PR:
- provide test

TODO for another iteration:
- support other places
- support `.asciidoctorconfig.adoc`
- provide a cache mechanism to avoid reading config file every time

Might not have time to work on it before 30th September but wanted to share current state