### PR TITLE
380 support recursive Asciidoctor file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- support `.asciidoctorconfig` and `.asciidoctorconfig.adoc` at root of the workspace by @apupier, @mogztter and @ahus1 (#380)
+- support `.asciidoctorconfig` and `.asciidoctorconfig.adoc` by @apupier, @mogztter and @ahus1 (#380)
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -168,11 +168,9 @@ Here's an example of how to use the [asciidoctor-emoji](https://github.com/mogzt
 
 ### Asciidoctor Config File
 
-To provide a common set of variables when rendering the preview, the extension reads an `.asciidoctorconfig` configuration file. Use this to optimize the preview when the project contains a document that is split out to multiple include-files.
+To provide a common set of variables when rendering the preview, the extension reads an `.asciidoctorconfig` or `.asciidoctorconfig.adoc` configuration file. Use this to optimize the preview when the project contains a document that is split out to multiple include-files.
 
 It is inspired by the implementation provided in [IntelliJ AsciiDoc Plugin](https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/asciidoctorconfig-file.html) and reused in [Eclipse AsciiDoc plugin](https://github.com/de-jcup/eclipse-asciidoctor-editor/wiki/Asciidoctor-configfiles).
-
-The current scope is limited to an `.asciidoctorconfig` or `.asciidoctorconfig.adoc` configuration file provided at the root of the workspace.
 
 ## Extension Settings
 


### PR DESCRIPTION
part of #380

Sharing current state. Only provided a test for now. /!\ it won't test all cases but I think it should give a good coverage already. This is based on https://github.com/asciidoctor/asciidoctor-vscode/pull/646

it might be a good idea to provide a different test for each assertion in the test. Will be less compact code but will improve reporting of use cases tested (and potentially broken)

I should continue working on it on the 21st October, unless someone wants to implement it, reusing or not my current progress.
