### PR TITLE
prepend asciidoctorconfigdir

### DIFF
--- a/src/features/asciidoctorConfig.ts
+++ b/src/features/asciidoctorConfig.ts
@@ -35,7 +35,7 @@ async function getConfigContent (workspaceFolder: vscode.WorkspaceFolder, config
   const asciidoctorConfigUri = vscode.Uri.joinPath(workspaceFolder.uri, configFilename)
   if (await exists(asciidoctorConfigUri)) {
     const asciidoctorConfigContent = new TextDecoder().decode(await vscode.workspace.fs.readFile(asciidoctorConfigUri))
-    return `${asciidoctorConfigContent.trim()}\n\n`
+    return `:asciidoctorconfigdir: ${workspaceFolder.uri.fsPath}\n\n${asciidoctorConfigContent.trim()}\n\n`
   }
   return undefined
 }


### PR DESCRIPTION
based on https://github.com/asciidoctor/asciidoctor-vscode/pull/646

Prepend :asciidoctorconfigdir: when using .asciidoctorconfig files

part of #380

similar to
https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/64707c7632e1c5e6efc34100dc3cb2dd0bab4ea6/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java#L730

