### PR TITLE
Fix completion after xref: for old double-square bracket notation

### DIFF
--- a/src/providers/xref.provider.ts
+++ b/src/providers/xref.provider.ts
@@ -30,14 +30,17 @@ function shouldProvide (context: Context): boolean {
 }
 
 async function getLabels (): Promise<string[]> {
-  const regex = /\\[\\[(\\w+)\\]\\]/g
-  const labels = await vscode.workspace.findFiles('**/*.adoc').then((files) =>
-    files
+  const regex = /\[\[(\w+)\]\]/g
+  const labels = await vscode.workspace.findFiles('**/*.adoc').then((files) => {
+    const contentOfFilesConcatenated = files
       .map((uri) => readFileSync(uri.path).toString('utf-8'))
       .join('\n')
-      .match(regex)
-      .map((result) => result.replace('[[', '').replace(']]', ''))
-  )
+    const matched = contentOfFilesConcatenated.match(regex)
+    if (matched) {
+      return matched.map((result) => result.replace('[[', '').replace(']]', ''))
+    }
+    return []
+  })
   return labels
 }
 

--- a/src/test/xrefCompletionProvider.test.ts
+++ b/src/test/xrefCompletionProvider.test.ts
@@ -1,0 +1,36 @@
+import 'mocha'
+import * as vscode from 'vscode'
+import assert from 'assert'
+import { xrefProvider } from '../providers/xref.provider'
+import { Position } from 'vscode'
+
+let root
+
+suite('Xref CompletionsProvider', () => {
+  const createdFiles: vscode.Uri[] = []
+  setup(() => {
+    root = vscode.workspace.workspaceFolders[0].uri.fsPath
+  })
+  teardown(async () => {
+    for (const createdFile of createdFiles) {
+      await vscode.workspace.fs.delete(createdFile)
+    }
+  })
+  test('Should return other ids from old style double-brackets as completion after "xref:"', async () => {
+    const fileToAutoComplete = vscode.Uri.file(`${root}/fileToAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileToAutoComplete, Buffer.from('xref:'))
+    createdFiles.push(fileToAutoComplete)
+
+    const fileThatShouldAppearInAutoComplete = vscode.Uri.file(`${root}/fileToAppearInAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileThatShouldAppearInAutoComplete, Buffer.from('[[anOldStyleID]]'))
+    createdFiles.push(fileThatShouldAppearInAutoComplete)
+
+    const file = await vscode.workspace.openTextDocument(fileToAutoComplete)
+    const completionsItems = await xrefProvider.provideCompletionItems(file, new Position(0, 5))
+    const filteredCompletionItems = completionsItems.filter((completionItem) => completionItem.label === 'anOldStyleID[]')
+    assert.deepStrictEqual(filteredCompletionItems[0], {
+      kind: vscode.CompletionItemKind.Reference,
+      label: 'anOldStyleID[]',
+    })
+  })
+})


### PR DESCRIPTION
part of #648

- it was broken during enforcing code style, the regular expression was not correctly converted
https://github.com/asciidoctor/asciidoctor-vscode/commit/cd477c7
- added a test
- Maybe not very nice in the sense that it is not inserting the file path but only the label, but maybe it is enough if there is the right include?

![image](https://user-images.githubusercontent.com/1105127/202731361-5dee5310-955e-4c18-b6d9-1c706c573b73.png)


