### PR TITLE
ref #648 provide completion short hand and long hand notation with similar scope of legacy

### DIFF
--- a/src/test/xrefCompletionProvider.test.ts
+++ b/src/test/xrefCompletionProvider.test.ts
@@ -7,7 +7,7 @@ import { Position } from 'vscode'
 let root
 
 suite('Xref CompletionsProvider', () => {
-  const createdFiles: vscode.Uri[] = []
+  let createdFiles: vscode.Uri[] = []
   setup(() => {
     root = vscode.workspace.workspaceFolders[0].uri.fsPath
   })
@@ -15,6 +15,7 @@ suite('Xref CompletionsProvider', () => {
     for (const createdFile of createdFiles) {
       await vscode.workspace.fs.delete(createdFile)
     }
+    createdFiles = []
   })
   test('Should return other ids from old style double-brackets as completion after "xref:"', async () => {
     const fileToAutoComplete = vscode.Uri.file(`${root}/fileToAutoComplete.adoc`)
@@ -31,6 +32,55 @@ suite('Xref CompletionsProvider', () => {
     assert.deepStrictEqual(filteredCompletionItems[0], {
       kind: vscode.CompletionItemKind.Reference,
       label: 'anOldStyleID[]',
+    })
+  })
+  test('Should return ids declared using the shorthand syntax as completion after "xref:"', async () => {
+    const fileToAutoComplete = vscode.Uri.file(`${root}/fileToAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileToAutoComplete, Buffer.from('xref:'))
+    createdFiles.push(fileToAutoComplete)
+
+    const fileThatShouldAppearInAutoComplete = vscode.Uri.file(`${root}/fileToAppearInAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileThatShouldAppearInAutoComplete, Buffer.from('[#aShortHandID]'))
+    createdFiles.push(fileThatShouldAppearInAutoComplete)
+
+    const file = await vscode.workspace.openTextDocument(fileToAutoComplete)
+    const completionsItems = await xrefProvider.provideCompletionItems(file, new Position(0, 5))
+    const filteredCompletionItems = completionsItems.filter((completionItem) => completionItem.label === 'aShortHandID[]')
+    assert.deepStrictEqual(filteredCompletionItems[0], {
+      kind: vscode.CompletionItemKind.Reference,
+      label: 'aShortHandID[]',
+    })
+  })
+  test('Should return ids declared using the longhand syntax as completion after "xref:"', async () => {
+    const fileToAutoComplete = vscode.Uri.file(`${root}/fileToAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileToAutoComplete, Buffer.from('xref:'))
+    createdFiles.push(fileToAutoComplete)
+
+    const fileThatShouldAppearInAutoComplete = vscode.Uri.file(`${root}/fileToAppearInAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileThatShouldAppearInAutoComplete, Buffer.from('[id=longHandID]'))
+    createdFiles.push(fileThatShouldAppearInAutoComplete)
+
+    const file = await vscode.workspace.openTextDocument(fileToAutoComplete)
+    const completionsItems = await xrefProvider.provideCompletionItems(file, new Position(0, 5))
+    const filteredCompletionItems = completionsItems.filter((completionItem) => completionItem.label === 'longHandID[]')
+    assert.deepStrictEqual(filteredCompletionItems[0], {
+      kind: vscode.CompletionItemKind.Reference,
+      label: 'longHandID[]',
+    })
+  })
+  test('Should return id for inlined anchor', async () => {
+    const fileToAutoComplete = vscode.Uri.file(`${root}/fileToTestXrefAutoComplete.adoc`)
+    await vscode.workspace.fs.writeFile(fileToAutoComplete, Buffer.from(`* [id=anInlinedAnchor]demo
+
+xref:`))
+    createdFiles.push(fileToAutoComplete)
+
+    const file = await vscode.workspace.openTextDocument(fileToAutoComplete)
+    const completionsItems = await xrefProvider.provideCompletionItems(file, new Position(2, 5))
+    const filteredCompletionItems = completionsItems.filter((completionItem) => completionItem.label === 'anInlinedAnchor[]')
+    assert.deepStrictEqual(filteredCompletionItems[0], {
+      kind: vscode.CompletionItemKind.Reference,
+      label: 'anInlinedAnchor[]',
     })
   })
 })


### PR DESCRIPTION
Provide completion after xref for ids defined with shorthand and
longhand notation

I.e. with [#myId] and [id=myId]

part of #648

![image](https://user-images.githubusercontent.com/1105127/202740708-b6db4319-fd8b-46e9-92ea-f62d2062d69b.png)

based on https://github.com/asciidoctor/asciidoctor-vscode/pull/667