### PR TITLE
(#678 , #680)feat: add ability for asciidocParser to pass the krokiServerUrl 

### DIFF
--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -156,7 +156,7 @@ export class AsciidocParser {
       this.contributionProvider.contributions,
       previewConfigurationManager.loadAndCacheConfiguration(doc.uri),
       antoraDocumentContext,
-      line
+      line,
       krokiServerUrl
     )
     processor.ConverterFactory.register(asciidoctorWebViewConverter, ['webview-html5'])

--- a/src/asciidocParser.ts
+++ b/src/asciidocParser.ts
@@ -144,6 +144,9 @@ export class AsciidocParser {
 
     // Antora IDs resolution:
     const antoraDocumentContext = await getAntoraDocumentContext(doc.uri, context.workspaceState)
+    // load the Asciidoc header only to get kroki-server-url attribute
+    const document = processor.load(text, { header_only: true })
+    const krokiServerUrl = document.getAttribute('kroki-server-url') || 'https://kroki.io'
 
     const asciidoctorWebViewConverter = new AsciidoctorWebViewConverter(
       doc,
@@ -154,6 +157,7 @@ export class AsciidocParser {
       previewConfigurationManager.loadAndCacheConfiguration(doc.uri),
       antoraDocumentContext,
       line
+      krokiServerUrl
     )
     processor.ConverterFactory.register(asciidoctorWebViewConverter, ['webview-html5'])
 

--- a/src/asciidoctorWebViewConverter.ts
+++ b/src/asciidoctorWebViewConverter.ts
@@ -100,7 +100,8 @@ export class AsciidoctorWebViewConverter {
     previewConfigurations: AsciidocPreviewConfiguration,
     private readonly antoraDocumentContext: AntoraDocumentContext | undefined,
     line: number | undefined = undefined,
-    state?: any
+    state?: any,
+    private readonly krokiServerUrl?: string
   ) {
     const textDocumentUri = textDocument.uri
     this.basebackend = 'html'


### PR DESCRIPTION
_References - #678, #680 - Add VSCode rule to allow kroki-server-url by default for local server content_

**Note:** This is the first part of #680 - Adding the ability for `asciidocParser` to pass the `krokiServerUrl` to the `asciidoctorWebViewConverter`. This is done by loading the Asciidoctor document using the `header_only` before we instantiate the `AsciidoctorWebViewConverter` in `asciidocParser.ts`. Then since `krokiServerUrl` should be defined at the parser level, and the value passed to the AsciidoctorWebViewConverter, I have added a new constructor argument named krokiServerUrl in `asciidoctorwebviewconverter`.

The next step will be to compute the CSP correctly. When enableKroki is true, we should always allow the krokiServerUrl no matter which security level is selected. -> Not sure 100% how I am going to make this work as CSP rules only get more restrictive.

Questions I have on this commit because I am very inexperienced with CSP rules and the complexity of the codebase here:

- It was originally stated that we might need to "add `enableKroki` and `krokiServerUrl` to the `AsciidocPreviewConfiguration`, then pass the configuration to the `getCspForResource` method" in #680. But it was later stated that we **should not** need to change the security level when `enableKroki` is true we should allow the `krokiServerUrl` no matter which security level is selected. This commit defines `const krokiServerUrl` in the `asciidocParser` and adds a new `krokiServerUrl` constructor to `AsciidoctorWebViewConverter`, but the cspRule will be looking for `krokiServerUrl` before the `AsciidoctorWebViewConverter` class is defined. So my question is, is it necessary to define `krokiServerUrl` before the `AsciidoctorWebViewConverter` class?

- For an example, `settings.json` section for the AsciiDoc extension looks like:
```
"asciidoc.extensions.enableKroki": true,
"asciidoc.preview.asciidoctorAttributes": {
  "kroki-server-url": "http://localhost:8000"
}
```
If now, the Asciidoctor attribute `kroki-server-url` is passed to the `asciidocParser` and `AsciidoctorWebViewConverter`, do we still also want/need to pass the "enableKroki" value from the vscode config `vscode.workspace.getConfiguration('asciidoc.extensions')` to the `AsciidoctorWebViewConverter` to compute the else, if for the cspRule?

@ggrossetie 