### PR TITLE
Folding mix of Attributes and single-line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - provide folding for list of sibling attributes by @apupier (#719)
+- provide folding for mix of attributes and single line comments by @apupier (#719)
 
 ### Bug fixes
 

--- a/src/test/foldingProvider.test.ts
+++ b/src/test/foldingProvider.test.ts
@@ -413,6 +413,77 @@ this is a paragraph`)
       ])
     })
   })
+
+  suite('getMultiAttributeAndSingleLineCommentsFoldingRanges', () => {
+    test('Should fold on a group of mix of attributes and single line comments ', () => {
+      const folds = getFoldsForDocument(
+        `this is a paragraph
+
+// A single-line comment.
+:an-attribute: value of attribute
+// A second single-line comment.
+:a-second-attribute: value of second attribute
+
+this is a paragraph`)
+      assert.strictEqual(folds.length, 1, 'expecting 1 fold')
+      assert.deepStrictEqual(folds, [
+        new vscode.FoldingRange(2, 5),
+      ])
+    })
+    test('Should fold on a group of mix of attributes and single line comments starting with 2 attributes', () => {
+      const folds = getFoldsForDocument(
+        `this is a paragraph
+
+:an-attribute1: value of attribute
+:an-attribute2: value of attribute
+// A single-line comment.
+:an-attribute: value of attribute
+// A second single-line comment.
+:a-second-attribute: value of second attribute
+
+this is a paragraph`)
+      assert.strictEqual(folds.length, 1, 'expecting 1 fold')
+      assert.deepStrictEqual(folds, [
+        new vscode.FoldingRange(2, 7),
+      ])
+    })
+    test('Should fold on a group of mix of attributes and single line comments starting with 2 line comments', () => {
+      const folds = getFoldsForDocument(
+        `this is a paragraph
+
+// A single-line comment.
+// A second single-line comment.
+:an-attribute: value of attribute
+// A third line comment
+:a-second-attribute: value of second attribute
+
+this is a paragraph`)
+      assert.strictEqual(folds.length, 1, 'expecting 1 fold')
+      assert.deepStrictEqual(folds, [
+        new vscode.FoldingRange(2, 6),
+      ])
+    })
+    test('Should fold on a group of mix of attributes and single line comments and include next groups', () => {
+      const folds = getFoldsForDocument(
+        `this is a paragraph
+
+// A single-line comment.
+// A second single-line comment.
+:an-attribute: value of attribute
+:another-attribute:
+// A third line comment
+// as a potential folded group
+:a-third-attribute: value of third attribute
+
+this is a paragraph`)
+      assert.strictEqual(folds.length, 3, 'expecting 3 folds')
+      assert.deepStrictEqual(folds, [
+        new vscode.FoldingRange(4, 5),
+        new vscode.FoldingRange(6, 7, vscode.FoldingRangeKind.Comment),
+        new vscode.FoldingRange(2, 8),
+      ])
+    })
+  })
 })
 
 function getFoldsForDocument (contents: string) {


### PR DESCRIPTION
It removes the possibility to have Folding range for the first group of attributes or first group of single-line comments. This is due to a limitation of VS Code which doesn't handle several folding ranges starting on the same line. This limitation lead me to add some non negligeable code complexity.

resolves #719


https://github.com/asciidoctor/asciidoctor-vscode/assets/1105127/5649fe55-47de-4265-b15c-c3d0047c6e6b

