### PR TITLE
fix regexes in #quote-paragraph rule, and downstream

### DIFF
--- a/syntaxes/Asciidoctor.json
+++ b/syntaxes/Asciidoctor.json
@@ -337,7 +337,7 @@
         {
           "comment": "attributes",
           "name": "markup.meta.attribute-list.asciidoc",
-          "match": "(?<=\\{|,|.|#|\"|'|%)([^\\],.#%]+)",
+          "match": "(?<=\\{|,|\\.|#|\"|'|%)(?:[^\\],.#%]|\\](?=[ \\t]*\\S))+",
           "captures": {
             "0": {
               "patterns": [
@@ -1710,10 +1710,10 @@
       "patterns": [
         {
           "name": "markup.italic.quotes.asciidoc",
-          "begin": "(?=(?>(?:^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$)))",
+          "begin": "(?=(?>(?:^\\[(quote|verse)(?:(?:,|#|\\.|%)(?:[^,\\]]|\\](?=[ \\t]*\\S))+)*\\]$)))",
           "patterns": [
             {
-              "match": "^\\[(quote|verse)((?:,|#|\\.|%)([^,\\]]+))*\\]$",
+              "match": "^\\[(quote|verse)(?:(?:,|#|\\.|%)(?:[^,\\]]|\\](?=[ \\t]*\\S))+)*\\]$",
               "captures": {
                 "0": {
                   "patterns": [


### PR DESCRIPTION
Addresses a problem in the grammar: As it stands, the regex in rule #quote-paragraph will not match any block-attribute-list that contains, itself, an inline macro -- such as a URL macro or a bibliographic-citation macro. Downstream from that rule, there are weaknesses also in the #block-attribute-inner rule. The fixes I've applied here are based on earlier discussion of this whole matter in [atom-language-asciidoc PR 197](https://github.com/asciidoctor/atom-language-asciidoc/pull/197) -- where there are screen-shots and syntax-examples.

Resolves #767.