### PR TITLE
fix asciidoc preview when antora is using version: true

### DIFF
--- a/src/features/antora/antoraSupport.ts
+++ b/src/features/antora/antoraSupport.ts
@@ -25,6 +25,9 @@ export class AntoraConfig {
     const path = uri.path
     this.contentSourceRootPath = path.slice(0, path.lastIndexOf('/'))
     this.contentSourceRootFsPath = ospath.dirname(uri.fsPath)
+    if (config.version === true) {
+      config.version = ''
+    }
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/asciidoctor/asciidoctor-vscode/issues/829

Currently if our antora.yml is using `version: true`, it is not possible to render a preview of the asciidoc file as version is expected to be a string and it fails with the following trace:

```
 Unable to get Antora context for .../antora/modules/ROOT/pages/index.adoc TypeError: The "path" argument must be of type string. Received type boolean (true)
    at NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.join (node:path:1165:7)
    at computeOut (/Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/node_modules/@antora/content-classifier/lib/content-catalog.js:500:27)
    at ContentCatalog.addFile (/Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/node_modules/@antora/content-classifier/lib/content-catalog.js:185:18)
    at /Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/node_modules/@antora/content-classifier/lib/classify-content.js:38:87
    at Array.forEach (<anonymous>)
    at /Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/node_modules/@antora/content-classifier/lib/classify-content.js:38:13
    at Map.forEach (<anonymous>)
    at classifyContent (/Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/node_modules/@antora/content-classifier/lib/classify-content.js:34:6)
    at /Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/src/features/antora/antoraSupport.ts:310:34
    at Generator.next (<anonymous>)
    at fulfilled (/Users/leonardo.pavan.rocha/tools/asciidoctor-vscode/dist/src/features/antora/antoraSupport.js:28:58) (at console.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:142:60451))
```

When antora is using `version: true`, it means that it will use the refname (branch/tags). Ideally the fix would use the refname, but I am not sure if we can access that from within the extension. I would appreciate any input on that. My approach was to simply replace it for an empty string for now.
