### PR TITLE
syntax: allow spaces after table delimiter. fix #894

### DIFF
--- a/syntaxes/Asciidoctor.json
+++ b/syntaxes/Asciidoctor.json
@@ -1998,7 +1998,7 @@
               "include": "#tables-includes"
             }
           ],
-          "end": "^(\\1\\s*)$",
+          "end": "^(\\1)\\s*$",
           "endCaptures": {
             "0": {
               "name": "markup.table.delimiter.asciidoc"

--- a/syntaxes/Asciidoctor.json
+++ b/syntaxes/Asciidoctor.json
@@ -1974,7 +1974,7 @@
       "patterns": [
         {
           "name": "markup.table.asciidoc",
-          "begin": "^(\\|===)$",
+          "begin": "^(\\|===)\\s*$",
           "beginCaptures": {
             "0": {
               "name": "markup.table.delimiter.asciidoc"
@@ -1998,7 +1998,7 @@
               "include": "#tables-includes"
             }
           ],
-          "end": "^(\\1)$",
+          "end": "^(\\1\\s*)$",
           "endCaptures": {
             "0": {
               "name": "markup.table.delimiter.asciidoc"


### PR DESCRIPTION
Change the `syntaxes/Asciidoctor.json` file to allow spaces after a table delimiter `|===`.

Tested locally on my setup.

Resolves #894.