### PR TITLE
quick includes from local folders (resolves #904)

### DIFF
--- a/i18n/de/package.i18n.json
+++ b/i18n/de/package.i18n.json
@@ -78,5 +78,6 @@
 	"asciidoc.use_kroki.deprecationMessage": "Diese Einstellung wurde durch `#asciidoc.extensions.enableKroki#` ersetzt und hat keine Auswirkungen mehr.",
 
 	"asciidoc.antora.title": "Antora",
-	"asciidoc.antora.enableAntoraSupport.desc": "Aktiviere [Antora](https://antora.org/) Unterstützung."
+	"asciidoc.antora.enableAntoraSupport.desc": "Aktiviere [Antora](https://antora.org/) Unterstützung.",
+	"asciidoc.antora.enableLocalIncludes.desc": "Aktiviert lokale Includes aus familienordnern, wenn Antora-Unterstützung deaktiviert ist."
 }

--- a/i18n/fra/package.i18n.json
+++ b/i18n/fra/package.i18n.json
@@ -38,6 +38,7 @@
 
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "Active le support [Antora](https://antora.org/).",
+	"asciidoc.antora.enableLocalIncludes.desc": "Active les inclusions locales à partir des dossiers de famille si le support d'Antora est désactivé.",
 
 	"asciidoc.pdf.title": "PDF",
 	"asciidoc.pdf.engine.desc": "Contrôle le moteur PDF à utiliser pour l'export PDF.",

--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -38,6 +38,7 @@
 
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "[Antora](https://antora.org/)サポートを有効にします。",
+	"asciidoc.antora.enableLocalIncludes.desc": "Antoraサポートが無効になっている場合、ファミリーフォルダーからのローカルインクルードを有効にします。",
 
 	"asciidoc.pdf.title": "PDF",
 	"asciidoc.pdf.engine.desc": "PDFエキスポートで使用するPDFエンジンを選択します。",

--- a/package.json
+++ b/package.json
@@ -556,6 +556,11 @@
 						"type": "boolean",
 						"default": false,
 						"markdownDescription": "%asciidoc.antora.enableAntoraSupport.desc%"
+					},
+					"asciidoc.antora.enableLocalIncludes": {
+						"type": "boolean",
+						"default": true,
+						"markdownDescription": "%asciidoc.antora.enableLocalIncludes.desc%"
 					}
 				}
 			}

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -69,5 +69,6 @@
 	"asciidoc.use_kroki.desc": "**Veraltet:** Aktiviert die Kroki-Integration zur Generierung von Diagrammen.",
 	"asciidoc.use_kroki.deprecationMessage": "Diese Einstellung wurde durch `#asciidoc.extensions.enableKroki#` ersetzt und hat keine Auswirkungen mehr.",
 	"asciidoc.antora.title": "Antora",
-	"asciidoc.antora.enableAntoraSupport.desc": "Aktiviere [Antora](https://antora.org/) Unterstützung."
+	"asciidoc.antora.enableAntoraSupport.desc": "Aktiviere [Antora](https://antora.org/) Unterstützung.",
+	"asciidoc.antora.enableLocalIncludes.desc": "Aktiviert lokale Includes aus familienordnern, wenn Antora-Unterstützung deaktiviert ist."
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -69,5 +69,6 @@
 	"asciidoc.use_kroki.desc": "**Obsolète:** Active l'extension Kroki afin de générer des diagrammes.",
 	"asciidoc.use_kroki.deprecationMessage": "Ce paramètre a été remplacé par `#asciidoc.extensions.enableKroki#` et n'a plus aucun effet.",
 	"asciidoc.antora.title": "Antora",
-	"asciidoc.antora.enableAntoraSupport.desc": "Active le support [Antora](https://antora.org/)."
+	"asciidoc.antora.enableAntoraSupport.desc": "Active le support [Antora](https://antora.org/).",
+	"asciidoc.antora.enableLocalIncludes.desc": "Active les inclusions locales à partir des dossiers de famille si le support d'Antora est désactivé."
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -69,5 +69,6 @@
 	"asciidoc.use_kroki.desc": "**非推奨:** ダイアグラム生成Krokiを使用します。",
 	"asciidoc.use_kroki.deprecationMessage": "本設定は、`#asciidoc.extensions.enableKroki#`に置き換えられ、動作しません。",
 	"asciidoc.antora.title": "Antora",
-	"asciidoc.antora.enableAntoraSupport.desc": "[Antora](https://antora.org/)サポートを有効にします。"
+	"asciidoc.antora.enableAntoraSupport.desc": "[Antora](https://antora.org/)サポートを有効にします。",
+	"asciidoc.antora.enableLocalIncludes.desc": "Antoraサポートが無効になっている場合、ファミリーフォルダーからのローカルインクルードを有効にします。"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -78,5 +78,6 @@
 	"asciidoc.use_kroki.deprecationMessage": "This setting has been replaced by `#asciidoc.extensions.enableKroki#` and no longer has any effect.",
 
 	"asciidoc.antora.title": "Antora",
-	"asciidoc.antora.enableAntoraSupport.desc": "Enable [Antora](https://antora.org/) support."
+	"asciidoc.antora.enableAntoraSupport.desc": "Enable [Antora](https://antora.org/) support.",
+	"asciidoc.antora.enableLocalIncludes.desc": "Enable local include from family folders if antora support is disabled."
 }

--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -15,6 +15,7 @@ import { AsciidoctorProcessor } from './asciidoctorProcessor'
 import { AsciidoctorAttributesConfig } from './features/asciidoctorAttributesConfig'
 import { IncludeProcessor } from './features/antora/includeProcessor'
 import { resolveIncludeFile } from './features/antora/resolveIncludeFile'
+import { registerLocalAntoraProcessors } from './features/antora/resolveLocalIncludeFile'
 
 const highlightjsAdapter = require('./highlightjs-adapter')
 
@@ -140,6 +141,9 @@ export class AsciidocEngine {
     await this.asciidoctorExtensionsProvider.activate(registry)
     const textDocumentUri = textDocument.uri
     await this.asciidoctorConfigProvider.activate(registry, textDocumentUri)
+
+    registerLocalAntoraProcessors(registry)
+
     if (antoraDocumentContext !== undefined) {
       const antoraConfig = await getAntoraConfig(textDocumentUri)
       registry.includeProcessor(IncludeProcessor.$new((_, target, cursor) => resolveIncludeFile(

--- a/src/asciidocLoader.ts
+++ b/src/asciidocLoader.ts
@@ -11,6 +11,7 @@ import { AsciidoctorIncludeItemsProvider, IncludeItems } from './features/asciid
 import { getAntoraDocumentContext, getAntoraConfig } from './features/antora/antoraSupport'
 import { IncludeProcessor } from './features/antora/includeProcessor'
 import { resolveIncludeFile } from './features/antora/resolveIncludeFile'
+import { registerLocalAntoraProcessors } from './features/antora/resolveLocalIncludeFile'
 
 export class AsciidocLoader {
   protected readonly processor: Asciidoctor
@@ -56,6 +57,9 @@ export class AsciidocLoader {
     await this.asciidoctorExtensionsProvider.activate(registry)
     const textDocumentUri = textDocument.uri
     await this.asciidoctorConfigProvider.activate(registry, textDocumentUri)
+
+    registerLocalAntoraProcessors(registry)
+
     const antoraDocumentContext = await getAntoraDocumentContext(textDocument.uri, this.context.workspaceState)
     if (antoraDocumentContext !== undefined) {
       const antoraConfig = await getAntoraConfig(textDocumentUri)

--- a/src/features/antora/resolveLocalIncludeFile.ts
+++ b/src/features/antora/resolveLocalIncludeFile.ts
@@ -1,0 +1,62 @@
+import vscode from 'vscode'
+import { Asciidoctor } from '@asciidoctor/core'
+import { readFileSync } from 'fs'
+
+const PERMITTED_FAMILIES = ['attachment', 'example', 'image', 'page', 'partial']
+
+function extractPartialModuleAndFilename (resourceId: string): { module?: string, family?: string, filename?: string } {
+  const regexString = `^(?:(.*):)?(${PERMITTED_FAMILIES.join('|')})\\$(.*)$`
+  const regex = new RegExp(regexString)
+  const matches = regex.exec(resourceId)
+  if (!matches) {
+    return {}
+  }
+
+  const [, module, family, filename] = matches
+  return { module, family, filename }
+}
+
+function isLocalAntoraIncludeEnabled () {
+  const workspaceConfiguration = vscode.workspace.getConfiguration('asciidoc', null)
+
+  // if Antora support is enabled, don't enable local includes
+  const enableAntoraSupport = workspaceConfiguration.get('antora.enableAntoraSupport') || false
+  if (enableAntoraSupport) {
+    return false
+  }
+
+  return workspaceConfiguration.get('antora.enableLocalIncludes')
+}
+
+const localFamilyInclude = function (this: Asciidoctor.Extensions.IncludeProcessorDsl): void {
+  const self = this
+  self.handles(function (target) {
+    if (!isLocalAntoraIncludeEnabled()) {
+      return false
+    }
+    const { filename } = extractPartialModuleAndFilename(target)
+    return filename !== undefined
+  })
+  self.process(function (doc, reader, target, attrs) {
+    const { module, family, filename } = extractPartialModuleAndFilename(target)
+
+    const currentDocumentPath = doc.getBaseDir()
+
+    const [antoraPath, currentRelativePath] = currentDocumentPath.split('/modules/')
+    const currentModule = currentRelativePath.split('/')[0]
+
+    const adjustedPath = `${antoraPath}/modules/${module || currentModule}/${family}s/${filename}`
+
+    try {
+      const content = readFileSync(adjustedPath, 'utf8')
+      reader.pushInclude(content, target, target, 1, attrs)
+    } catch (e) {
+      reader.getLogger().error(e)
+      reader.pushInclude(`Unresolved include: ${target} (tried ${adjustedPath})`, target, target, 1, attrs)
+    }
+  })
+}
+
+export function registerLocalAntoraProcessors (registry: Asciidoctor.Extensions.Registry) {
+  registry.includeProcessor(localFamilyInclude)
+}


### PR DESCRIPTION
This PR (resolves #904 ) allows for antora includes resource ID like `include::module:family$filename[]` to be resolved directly without relying on an antora configuration.

This is enabled only if the setting `antora.enableAntoraSupport` is false (to avoid conflicts with proper management of resource IDs) and if `antora.enableLocalIncludes` is true (which I set at true by default in this PR).

Changes are:
* Create an `IncludeProcessor` to handle the targetted resourceIds,
* Register that includeProcessor
* Add the new `antora.enableLocalIncludes` setting
* Document the new `antora.enableLocalIncludes` setting (thank you Copilot for translation in languages I don't know)