### PR TITLE
use ripgrep instead of vscode findFiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"util": "^0.12.5",
 				"uuid": "8.3.2",
 				"vscode-nls": "5.2.0",
+				"vscode-ripgrep": "^1.13.2",
 				"vscode-uri": "^3.0.3",
 				"worker-thread": "^1.1.0"
 			},
@@ -3775,7 +3776,6 @@
 			"version": "4.3.5",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
 			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -9224,8 +9224,7 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/mute-stdout": {
 			"version": "1.0.1",
@@ -10553,6 +10552,11 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
 			"integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA=="
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -13416,6 +13420,37 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/vscode-ripgrep": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/vscode-ripgrep/-/vscode-ripgrep-1.13.2.tgz",
+			"integrity": "sha512-RlK9U87EokgHfiOjDQ38ipQQX936gWOcWPQaJpYf+kAkz1PQ1pK2n7nhiscdOmLu6XGjTs7pWFJ/ckonpN7twQ==",
+			"deprecated": "This package has been renamed to @vscode/ripgrep, please update to the new name",
+			"hasInstallScript": true,
+			"dependencies": {
+				"https-proxy-agent": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"node_modules/vscode-ripgrep/node_modules/agent-base": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/vscode-ripgrep/node_modules/https-proxy-agent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+			"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+			"dependencies": {
+				"agent-base": "5",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -662,6 +662,7 @@
 		"util": "^0.12.5",
 		"uuid": "8.3.2",
 		"vscode-nls": "5.2.0",
+		"vscode-ripgrep": "^1.13.2",
 		"vscode-uri": "^3.0.3",
 		"worker-thread": "^1.1.0"
 	},

--- a/src/features/antora/antoraSupport.ts
+++ b/src/features/antora/antoraSupport.ts
@@ -9,6 +9,7 @@ import ContentCatalog from '@antora/content-classifier/content-catalog'
 import { getWorkspaceFolder } from '../../util/workspace'
 import { dir, exists } from '../../util/file'
 import * as contentClassifier from '@antora/content-classifier'
+import { wrappedFindFiles } from '../../util/wrappedFindFiles'
 const classifyContent = contentClassifier.default || contentClassifier
 
 const MAX_DEPTH_SEARCH_ANTORA_CONFIG = 100
@@ -192,7 +193,7 @@ export async function findAntoraConfigFile (textDocumentUri: Uri): Promise<Uri |
   cancellationToken.token.onCancellationRequested((e) => {
     console.log('Cancellation requested, cause: ' + e)
   })
-  const antoraConfigUris = await vscode.workspace.findFiles('**/antora.yml', undefined, 100, cancellationToken.token)
+  const antoraConfigUris = await wrappedFindFiles('**/antora.yml')
   // check for Antora configuration
   for (const antoraConfigUri of antoraConfigUris) {
     const antoraConfigParentDirPath = antoraConfigUri.path.slice(0, antoraConfigUri.path.lastIndexOf('/'))
@@ -238,7 +239,7 @@ export async function getAntoraConfigs (): Promise<AntoraConfig[]> {
   cancellationToken.token.onCancellationRequested((e) => {
     console.log('Cancellation requested, cause: ' + e)
   })
-  const antoraConfigUris = await vscode.workspace.findFiles('**/antora.yml', undefined, 100, cancellationToken.token)
+  const antoraConfigUris = await wrappedFindFiles('**/antora.yml')
   // check for Antora configuration
   const antoraConfigs = await Promise.all(antoraConfigUris.map(async (antoraConfigUri) => {
     let config = {}
@@ -293,7 +294,7 @@ export async function getAntoraDocumentContext (textDocumentUri: Uri, workspaceS
         const workspaceFolder = getWorkspaceFolder(antoraConfig.uri)
         const workspaceRelative = posixpath.relative(workspaceFolder.uri.path, antoraConfig.contentSourceRootPath)
         const globPattern = 'modules/*/{attachments,examples,images,pages,partials,assets}/**'
-        const files = await Promise.all((await vscode.workspace.findFiles(`${workspaceRelative ? `${workspaceRelative}/` : ''}${globPattern}`)).map(async (file) => {
+        const files = await Promise.all((await wrappedFindFiles(`${workspaceRelative ? `${workspaceRelative}/` : ''}${globPattern}`)).map(async (file) => {
           const contentSourceRootPath = antoraConfig.contentSourceRootPath
           return {
             base: contentSourceRootPath,

--- a/src/features/asciidoctorExtensions.ts
+++ b/src/features/asciidoctorExtensions.ts
@@ -2,6 +2,7 @@ import vscode from 'vscode'
 import { AsciidoctorExtensionsSecurityPolicyArbiter } from '../security'
 import { Asciidoctor } from '@asciidoctor/core'
 import { mermaidJSProcessor } from './mermaid'
+import { wrappedFindFiles } from '../util/wrappedFindFiles'
 
 export interface AsciidoctorExtensionsProvider {
   activate(registry: Asciidoctor.Extensions.Registry): Promise<void>;
@@ -38,7 +39,7 @@ export class AsciidoctorExtensions {
   }
 
   private async getExtensionFilesInWorkspace (): Promise<vscode.Uri[]> {
-    return vscode.workspace.findFiles('.asciidoctor/lib/**/*.js')
+    return wrappedFindFiles('.asciidoctor/lib/**/*.js')
   }
 
   private isAsciidoctorExtensionsRegistrationEnabled (): boolean {

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -8,6 +8,7 @@ import { isAsciidocFile } from '../util/file'
 import { Lazy, lazy } from '../util/lazy'
 import AdocDocumentSymbolProvider from './documentSymbolProvider'
 import { SkinnyTextDocument } from '../util/document'
+import { wrappedFindFiles } from '../util/wrappedFindFiles'
 
 export interface WorkspaceAsciidocDocumentProvider {
   getAllAsciidocDocuments(): Promise<Iterable<SkinnyTextDocument>>;
@@ -37,7 +38,7 @@ class VSCodeWorkspaceAsciidocDocumentProvider implements WorkspaceAsciidocDocume
   }
 
   async getAllAsciidocDocuments () {
-    const resources = await vscode.workspace.findFiles('**/*.adoc', '**/node_modules/**')
+    const resources = await wrappedFindFiles('**/*.adoc')
     const docs = await Promise.all(resources.map((doc) => this.getAsciidocDocument(doc)))
     return docs.filter((doc) => !!doc) as SkinnyTextDocument[]
   }

--- a/src/providers/bibtex.provider.ts
+++ b/src/providers/bibtex.provider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import { createContext, Context } from './createContext'
 import { readFileSync } from 'fs'
+import { wrappedFindFiles } from '../util/wrappedFindFiles'
 const bibtexParse = require('@orcid/bibtex-parse-js')
 
 export const BibtexProvider = {
@@ -31,7 +32,7 @@ function shouldProvide (context: Context): boolean {
 }
 
 async function getCitationKeys (): Promise<string[]> {
-  const files = await vscode.workspace.findFiles('*.bib')
+  const files = await wrappedFindFiles('*.bib')
   const filesContent = files.map((file) =>
     readFileSync(file.path).toString('utf-8')
   )

--- a/src/providers/xref.provider.ts
+++ b/src/providers/xref.provider.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { createContext, Context } from './createContext'
+import { wrappedFindFiles } from '../util/wrappedFindFiles'
 
 export const xrefProvider = {
   provideCompletionItems,
@@ -83,7 +84,7 @@ async function provideCrossRef (context: Context): Promise<vscode.CompletionItem
   )
 
   const completionItems: vscode.CompletionItem[] = []
-  const workspacesAdocFiles = await vscode.workspace.findFiles('**/*.adoc')
+  const workspacesAdocFiles = await wrappedFindFiles('**/*.adoc')
   for (const adocFile of workspacesAdocFiles) {
     const labels = await getIdsFromFile(adocFile)
     for (const label of labels) {

--- a/src/util/wrappedFindFiles.ts
+++ b/src/util/wrappedFindFiles.ts
@@ -5,7 +5,7 @@ import { getWorkspaceFolders } from './workspace'
 
 async function ripgrep (glob: string, rootFolder: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    const rg = spawn(rgPath, ['--files', '-g', glob], { cwd: rootFolder })
+    const rg = spawn(rgPath, ['--hidden', '--files', '-g', glob], { cwd: rootFolder })
     let stdout : string = ''
     let stderr = ''
 

--- a/src/util/wrappedFindFiles.ts
+++ b/src/util/wrappedFindFiles.ts
@@ -23,6 +23,8 @@ async function ripgrep (glob: string, rootFolder: string): Promise<string[]> {
           .map((path) => path.trim())
           .filter((path) => !!path) // ensure empty strings are deleted from answer
         resolve(result)
+      } else if (code === 1) {
+        resolve([])
       } else {
         reject(new Error(`code ${code}: ${stderr}`))
       }

--- a/src/util/wrappedFindFiles.ts
+++ b/src/util/wrappedFindFiles.ts
@@ -1,0 +1,64 @@
+import { spawn } from 'child_process'
+import { rgPath } from 'vscode-ripgrep'
+import { Uri } from 'vscode'
+import { getWorkspaceFolders } from './workspace'
+
+async function ripgrep (glob: string, rootFolder: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const rg = spawn(rgPath, ['--files', '-g', glob], { cwd: rootFolder })
+    let stdout : string = ''
+    let stderr = ''
+
+    rg.stdout.on('data', (data) => {
+      stdout += data.toString()
+    })
+
+    rg.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    rg.on('close', (code) => {
+      if (code === 0) {
+        const result = stdout.split('\n')
+          .map((path) => path.trim())
+          .filter((path) => !!path) // ensure empty strings are deleted from answer
+        resolve(result)
+      } else {
+        reject(new Error(`code ${code}: ${stderr}`))
+      }
+    })
+
+    rg.on('error', (err) => {
+      reject(err)
+    })
+  })
+}
+
+async function internalWrappedFindFiles (glob: string): Promise<Uri[]> {
+  // const uris = await vscode.workspace.findFiles(glob, undefined, 100, token)
+  const searchedUris : Uri[] = []
+
+  for (const workspaceFolder of getWorkspaceFolders()) {
+    const rootUri = workspaceFolder.uri
+    const paths = await ripgrep(glob, rootUri.path)
+    searchedUris.push(...paths.map((path) => Uri.joinPath(rootUri, path)))
+  }
+  return searchedUris
+}
+
+const cache: Map<string, { timestamp: number, uris: Uri[] }> = new Map()
+
+function isCacheValid (timestamp: number): boolean {
+  return (Date.now() - timestamp) < 5000
+}
+
+export async function wrappedFindFiles (glob: string): Promise<Uri[]> {
+  const cacheEntry = cache.get(glob)
+  if (cacheEntry && isCacheValid(cacheEntry.timestamp)) {
+    return cacheEntry.uris
+  }
+
+  const uris = await internalWrappedFindFiles(glob)
+  cache.set(glob, { timestamp: Date.now(), uris })
+  return uris
+}

--- a/src/util/wrappedFindFiles.ts
+++ b/src/util/wrappedFindFiles.ts
@@ -5,7 +5,7 @@ import { getWorkspaceFolders } from './workspace'
 
 async function ripgrep (glob: string, rootFolder: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    const rg = spawn(rgPath, ['--hidden', '--files', '-g', glob], { cwd: rootFolder })
+    const rg = spawn(rgPath, ['--hidden', '--follow', '--files', '-g', glob], { cwd: rootFolder })
     let stdout : string = ''
     let stderr = ''
 


### PR DESCRIPTION
@ggrossetie  this attempt uses `ripgrep` directly (getting the right path to the version embedded in vscode using `vscode-ripgrep` published by Microsoft).

Significantly increases the performance, because ripgrep by default excludes gitignored files and symlinks.

Had to disregard the cancellation token used before. Not sure that is an issue.

This could be replaced by the upgraded findFiles once it is finalised by the vscode team.

Curious to know what you think.

resolves #907 to a great extent