### PR TITLE
Config ripgrep

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,26 @@
 {
-    "javascript.format.placeOpenBraceOnNewLineForFunctions": true,
-    "javascript.format.placeOpenBraceOnNewLineForControlBlocks": true,
-    "typescript.format.placeOpenBraceOnNewLineForFunctions": true,
-    "typescript.format.placeOpenBraceOnNewLineForControlBlocks": true,
-    "cSpell.words": [
-        "asciidoctor",
-        "deserialize",
-        "helvetica",
-        "joaompinto",
-        "junit",
-        "linkify",
-        "neue",
-        "plantuml",
-        "segoe",
-        "webview"
-    ],
-    "files.watcherExclude": {
-        "out/**": true,
-        "dist/**": true
-    },
+  "javascript.format.placeOpenBraceOnNewLineForFunctions": true,
+  "javascript.format.placeOpenBraceOnNewLineForControlBlocks": true,
+  "typescript.format.placeOpenBraceOnNewLineForFunctions": true,
+  "typescript.format.placeOpenBraceOnNewLineForControlBlocks": true,
+  "cSpell.words": [
+    "asciidoctor",
+    "deserialize",
+    "helvetica",
+    "joaompinto",
+    "junit",
+    "linkify",
+    "neue",
+    "plantuml",
+    "segoe",
+    "webview"
+  ],
+  "files.watcherExclude": {
+    "out/**": true,
+    "dist/**": true
+  },
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -582,6 +582,23 @@
 						"markdownDescription": "%asciidoc.antora.showEnableAntoraPrompt.desc%"
 					}
 				}
+			},
+			{
+				"order": 27,
+				"id": "security",
+				"title": "%asciidoc.findfiles.title%",
+				"properties": {
+					"asciidoc.findfiles.useRipgrep": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "%asciidoc.findfiles.useRipgrep.desc%"
+					},
+					"asciidoc.findfiles.ripgrepPath": {
+						"type": "string",
+						"default": "",
+						"markdownDescription": "%asciidoc.findfiles.ripgrepPath.desc%"
+					}
+				}
 			}
 		],
 		"configurationDefaults": {

--- a/package.json
+++ b/package.json
@@ -585,18 +585,18 @@
 			},
 			{
 				"order": 27,
-				"id": "security",
-				"title": "%asciidoc.findfiles.title%",
+				"id": "findFiles",
+				"title": "%asciidoc.findFiles.title%",
 				"properties": {
-					"asciidoc.findfiles.useRipgrep": {
+					"asciidoc.findFiles.useRipgrep": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "%asciidoc.findfiles.useRipgrep.desc%"
+						"markdownDescription": "%asciidoc.findFiles.useRipgrep.desc%"
 					},
-					"asciidoc.findfiles.ripgrepPath": {
+					"asciidoc.findFiles.ripgrepPath": {
 						"type": "string",
 						"default": "",
-						"markdownDescription": "%asciidoc.findfiles.ripgrepPath.desc%"
+						"markdownDescription": "%asciidoc.findFiles.ripgrepPath.desc%"
 					}
 				}
 			}

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -74,7 +74,7 @@
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "Aktiviere [Antora](https://antora.org/) Unterstützung.",
 	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected.",
-	"asciidoc.findfiles.title": "Find files",
-	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
-	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
+	"asciidoc.findFiles.title": "Find files",
+	"asciidoc.findFiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findFiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -73,5 +73,8 @@
 	"asciidoc.antora.enableAntoraSupport.deprecationMessage": "This setting has been replaced by `#asciidoc.antora.showEnableAntoraPrompt#` and no longer has any effect.",
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "Aktiviere [Antora](https://antora.org/) Unterstützung.",
-	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected."
+	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected.",
+	"asciidoc.findfiles.title": "Find files",
+	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -73,5 +73,8 @@
 	"asciidoc.antora.enableAntoraSupport.deprecationMessage": "Ce paramètre a été remplacé par `#asciidoc.antora.showEnableAntoraPrompt#` et n'a plus aucun effet.",
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "Active le support [Antora](https://antora.org/).",
-	"asciidoc.antora.showEnableAntoraPrompt.desc": "Affiche une fenêtre contextuelle permettant d'activer le support [Antora](https://antora.org/) quand un fichier antora.yml est trouvé."
+	"asciidoc.antora.showEnableAntoraPrompt.desc": "Affiche une fenêtre contextuelle permettant d'activer le support [Antora](https://antora.org/) quand un fichier antora.yml est trouvé.",
+	"asciidoc.findfiles.title": "Find files",
+	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -74,7 +74,7 @@
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "Active le support [Antora](https://antora.org/).",
 	"asciidoc.antora.showEnableAntoraPrompt.desc": "Affiche une fenêtre contextuelle permettant d'activer le support [Antora](https://antora.org/) quand un fichier antora.yml est trouvé.",
-	"asciidoc.findfiles.title": "Find files",
-	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
-	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
+	"asciidoc.findFiles.title": "Find files",
+	"asciidoc.findFiles.useRipgrep.desc": "Utiliser ripgrep pour rechercher des fichiers dans l'espace de travail.",
+	"asciidoc.findFiles.ripgrepPath.desc": "Commande externe `rg` à exécuter. Accepte un chemin complet vers le binaire, par exemple : `/path/to/rg`. Si la valeur est vide, utilise ripgrep de la version intégrée de VSCode."
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -73,5 +73,8 @@
 	"asciidoc.antora.enableAntoraSupport.deprecationMessage": "This setting has been replaced by `#asciidoc.antora.showEnableAntoraPrompt#` and no longer has any effect.",
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "[Antora](https://antora.org/)サポートを有効にします。",
-	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected."
+	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected.",
+	"asciidoc.findfiles.title": "Find files",
+	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -74,7 +74,7 @@
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "[Antora](https://antora.org/)サポートを有効にします。",
 	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected.",
-	"asciidoc.findfiles.title": "Find files",
-	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
-	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
+	"asciidoc.findFiles.title": "Find files",
+	"asciidoc.findFiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findFiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -82,5 +82,9 @@
 
 	"asciidoc.antora.title": "Antora",
 	"asciidoc.antora.enableAntoraSupport.desc": "Enable [Antora](https://antora.org/) support.",
-	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected."
+	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected.",
+	
+	"asciidoc.findfiles.title": "Find files",
+	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -84,7 +84,7 @@
 	"asciidoc.antora.enableAntoraSupport.desc": "Enable [Antora](https://antora.org/) support.",
 	"asciidoc.antora.showEnableAntoraPrompt.desc": "Show a prompt to enable [Antora](https://antora.org/) support when an antora.yml file is detected.",
 	
-	"asciidoc.findfiles.title": "Find files",
-	"asciidoc.findfiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
-	"asciidoc.findfiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
+	"asciidoc.findFiles.title": "Find files",
+	"asciidoc.findFiles.useRipgrep.desc": "Use ripgrep to search for files in the workspace.",
+	"asciidoc.findFiles.ripgrepPath.desc": "External `rg` command to execute. It accepts a full path to the binary, for instance: `/path/to/rg`. If the value is empty, use ripgrep from VSCode's built-in version."
 }

--- a/src/util/findFiles.ts
+++ b/src/util/findFiles.ts
@@ -1,9 +1,69 @@
+import { spawn } from 'child_process'
+import ospath from 'path'
 import vscode, { Uri } from 'vscode'
+import { getWorkspaceFolders } from './workspace'
 
 /**
  * Find files across all workspace folders in the workspace using a glob expression.
+ * Use `@vscode/ripgrep` to find files when there is a platform shell present.
  * @param glob A glob pattern that defines the files to search for.
  */
 export async function findFiles (glob: string): Promise<Uri[]> {
-  return vscode.workspace.findFiles(glob)
+  const isBrowser = ((process as any)?.browser === true)
+  const useRipgrep = (vscode.workspace.getConfiguration('asciidoc', null).get('registerAsciidoctorExtensions') === true)
+
+  if (isBrowser || !useRipgrep) {
+    return vscode.workspace.findFiles(glob)
+  }
+  const searchedUris: Uri[] = []
+  for (const workspaceFolder of getWorkspaceFolders()) {
+    const rootUri = workspaceFolder.uri
+    const paths = await ripgrep(glob, rootUri.fsPath)
+    searchedUris.push(...paths.map((path) => Uri.joinPath(rootUri, path)))
+  }
+  return searchedUris
+}
+
+async function ripgrep (glob: string, rootFolder: string): Promise<string[]> {
+  const config = vscode.workspace.getConfiguration('asciidoc.findfiles')
+  const customPath = config.get<string>('ripgrepPath')
+  const rgPath = customPath || ospath.join(
+    vscode.env.appRoot,
+    `node_modules/@vscode/ripgrep/bin/rg${
+      process.platform === 'win32' ? '.exe' : ''
+    }`
+  )
+  return new Promise((resolve, reject) => {
+    const rg = spawn(rgPath, ['--hidden', '--follow', '--files', '-g', glob], {
+      cwd: rootFolder,
+    })
+    let stdout: string = ''
+    let stderr = ''
+
+    rg.stdout.on('data', (data) => {
+      stdout += data.toString()
+    })
+
+    rg.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    rg.on('close', (code) => {
+      if (code === 0) {
+        const result = stdout
+          .split('\n')
+          .map((path) => path.trim())
+          .filter((path) => !!path) // ensure empty strings are deleted from answer
+        resolve(result)
+      } else if (code === 1) {
+        resolve([])
+      } else {
+        reject(new Error(`code ${code}: ${stderr}`))
+      }
+    })
+
+    rg.on('error', (err) => {
+      reject(err)
+    })
+  })
 }

--- a/src/util/findFiles.ts
+++ b/src/util/findFiles.ts
@@ -10,7 +10,7 @@ import { getWorkspaceFolders } from './workspace'
  */
 export async function findFiles (glob: string): Promise<Uri[]> {
   const isBrowser = ((process as any)?.browser === true)
-  const useRipgrep = (vscode.workspace.getConfiguration('asciidoc', null).get('registerAsciidoctorExtensions') === true)
+  const useRipgrep = (vscode.workspace.getConfiguration('asciidoc', null).get('findFiles.useRipgrep') === true)
 
   if (isBrowser || !useRipgrep) {
     return vscode.workspace.findFiles(glob)
@@ -25,7 +25,7 @@ export async function findFiles (glob: string): Promise<Uri[]> {
 }
 
 async function ripgrep (glob: string, rootFolder: string): Promise<string[]> {
-  const config = vscode.workspace.getConfiguration('asciidoc.findfiles')
+  const config = vscode.workspace.getConfiguration('asciidoc.findFiles')
   const customPath = config.get<string>('ripgrepPath')
   const rgPath = customPath || ospath.join(
     vscode.env.appRoot,


### PR DESCRIPTION
fixes issue #922

This pull request introduces several changes to enhance the `asciidoc` extension by adding new settings for file search functionality . The most important changes include adding the ability to use `ripgrep` for file searches, updating configuration files, and modifying the `findFiles` utility function.


Enhancements to file search functionality:

* [`src/util/findFiles.ts`](diffhunk://#diff-8f1ea689aa258b27f85120bc2c88e5b1b95eda0c499c08b019b7c04ec0c0deedR1-R69): Added functionality to use `ripgrep` for searching files in the workspace, including handling custom paths and fallback to built-in `ripgrep` if not specified.

Configuration updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R585-R601): Added new configuration settings for `findFiles` to enable and configure the use of `ripgrep`.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R22-R25): Disabled format on save and enabled ESLint fixes on save.

Translation updates:

* `package.nls.de.json`, `package.nls.fr.json`, `package.nls.ja.json`, `package.nls.json`: Updated translations to include descriptions for the new `findFiles` settings. [[1]](diffhunk://#diff-129d8892a48672ed3a6a33088c027c9dcd6dfb00b562866c646a238d6227b865L76-R79) [[2]](diffhunk://#diff-522adfcc80c214fb3b0668bce6a71009ac99368bd4200c6ccdff620ce0bdfea5L76-R79) [[3]](diffhunk://#diff-bccfdba50bb5f275458582efa5f3afa08f0d01dbdf38738295f1956007e042d6L76-R79) [[4]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L85-R89)