### PR TITLE
Correct footnote begin

### DIFF
--- a/syntaxes/Asciidoctor.json
+++ b/syntaxes/Asciidoctor.json
@@ -841,7 +841,7 @@
       "patterns": [
         {
           "name": "markup.other.footnote.asciidoc",
-          "begin": "(?<!\\\\)footnote(?:(ref):|:([\\w-]+)?)\\[(?:|(.*?[^\\\\]))\\]",
+          "begin": "(?<!\\\\)footnote(?:(ref):|:([\\w-]+)?)\\[(?:|(.*?[^\\\\]))",
           "beginCaptures": {
             "1": {
               "name": "entity.name.function.asciidoc"


### PR DESCRIPTION
This PR fixes the `begin` regex for footnotes

Fixes https://github.com/asciidoctor/asciidoctor-vscode/issues/930