### PR TITLE
Fix: Strip leading slash from Windows paths in baseDir and config

### DIFF
--- a/src/asciidocEngine.ts
+++ b/src/asciidocEngine.ts
@@ -52,7 +52,10 @@ export class AsciidocEngine {
     await this.asciidoctorConfigProvider.activate(registry, textDocumentUri)
     asciidoctorProcessor.restoreBuiltInSyntaxHighlighter()
 
-    const baseDir = AsciidocTextDocument.fromTextDocument(textDocument).baseDir
+    let baseDir = AsciidocTextDocument.fromTextDocument(textDocument).baseDir
+    if (baseDir && baseDir.startsWith('/') && baseDir.includes(':')) {
+      baseDir = baseDir.substring(1)
+    }
     const options: { [key: string]: any } = {
       attributes: {
         'env-vscode': '',
@@ -188,7 +191,10 @@ export class AsciidocEngine {
     const antoraAttributes = await antoraSupport.getAttributes(textDocumentUri)
     const asciidocTextDocument =
       AsciidocTextDocument.fromTextDocument(textDocument)
-    const baseDir = asciidocTextDocument.baseDir
+    let baseDir = asciidocTextDocument.baseDir
+    if (baseDir && baseDir.startsWith('/') && baseDir.includes(':')) {
+      baseDir = baseDir.substring(1)
+    }
     const documentDirectory = asciidocTextDocument.dirName
     const documentBasename = asciidocTextDocument.fileName
     const documentExtensionName = asciidocTextDocument.extensionName

--- a/src/features/asciidoctorConfig.ts
+++ b/src/features/asciidoctorConfig.ts
@@ -103,10 +103,17 @@ export async function getAsciidoctorConfigContent(
     const asciidoctorConfigContent = new TextDecoder().decode(
       await vscode.workspace.fs.readFile(asciidoctorConfig),
     )
-    const asciidoctorConfigParentDirectory = asciidoctorConfig.path.slice(
+    let asciidoctorConfigParentDirectory = asciidoctorConfig.path.slice(
       0,
       asciidoctorConfig.path.lastIndexOf('/'),
     )
+    if (
+      asciidoctorConfigParentDirectory.startsWith('/') &&
+      asciidoctorConfigParentDirectory.includes(':')
+    ) {
+      asciidoctorConfigParentDirectory =
+        asciidoctorConfigParentDirectory.substring(1)
+    }
     configContents.push(
       `:asciidoctorconfigdir: ${asciidoctorConfigParentDirectory}\n\n${asciidoctorConfigContent.trim()}\n\n`,
     )


### PR DESCRIPTION
## Description
This PR fixes an issue on Windows where `vscode.Uri.path` (and consequently `baseDir`) sometimes includes a leading slash (e.g., `/c:/Users/...`). When this path is passed to Asciidoctor, it fails to resolve includes because it treats the path as a malformed absolute path or a relative path.

## Changes
- Modified `src/features/asciidoctorConfig.ts`: Added a check to strip the leading slash from `asciidoctorConfigParentDirectory` if it looks like a Windows drive path (starts with `/` and contains `:`).
- Modified `src/asciidocEngine.ts`: Added the same sanitization logic for `baseDir` in both `export` and `convertFromTextDocument` methods.

## How to Test
1. On a Windows machine, open a workspace with an AsciiDoc file that uses `include::` directives.
2. Ensure the extension is running the patched version.
3. Verify that the preview renders correctly and includes are resolved.
4. Verify that `.asciidoctorconfig` files are correctly loaded.

## Related Issues
Resolves #897
Resolves #902

