### PR TITLE
fix(grammar): allow leading/trailing whitespace on block macro lines

### DIFF
--- a/syntaxes/asciidoc.tmLanguage.base.json
+++ b/syntaxes/asciidoc.tmLanguage.base.json
@@ -858,15 +858,18 @@
       "patterns": [
         {
           "name": "markup.macro.block.general.asciidoc",
-          "match": "^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])$",
+          "match": "^(\\s*)(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])(\\s*)$",
           "captures": {
             "1": {
-              "name": "entity.name.function.asciidoc"
+              "name": "meta.leading-whitespace.asciidoc"
             },
             "2": {
-              "name": "punctuation.separator.asciidoc"
+              "name": "entity.name.function.asciidoc"
             },
             "3": {
+              "name": "punctuation.separator.asciidoc"
+            },
+            "4": {
               "name": "markup.link.asciidoc",
               "patterns": [
                 {
@@ -874,10 +877,10 @@
                 }
               ]
             },
-            "4": {
+            "5": {
               "name": "punctuation.separator.asciidoc"
             },
-            "5": {
+            "6": {
               "name": "string.unquoted.asciidoc",
               "patterns": [
                 {
@@ -885,8 +888,11 @@
                 }
               ]
             },
-            "6": {
+            "7": {
               "name": "punctuation.separator.asciidoc"
+            },
+            "8": {
+              "name": "meta.trailing-whitespace.asciidoc"
             }
           }
         }

--- a/syntaxes/asciidoc.tmLanguage.json
+++ b/syntaxes/asciidoc.tmLanguage.json
@@ -864,15 +864,18 @@
       "patterns": [
         {
           "name": "markup.macro.block.general.asciidoc",
-          "match": "^(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])$",
+          "match": "^(\\s*)(\\p{Word}+)(::)(\\S*?)(\\[)((?:\\\\\\]|[^\\]])*?)(\\])(\\s*)$",
           "captures": {
             "1": {
-              "name": "entity.name.function.asciidoc"
+              "name": "meta.leading-whitespace.asciidoc"
             },
             "2": {
-              "name": "punctuation.separator.asciidoc"
+              "name": "entity.name.function.asciidoc"
             },
             "3": {
+              "name": "punctuation.separator.asciidoc"
+            },
+            "4": {
               "name": "markup.link.asciidoc",
               "patterns": [
                 {
@@ -880,10 +883,10 @@
                 }
               ]
             },
-            "4": {
+            "5": {
               "name": "punctuation.separator.asciidoc"
             },
-            "5": {
+            "6": {
               "name": "string.unquoted.asciidoc",
               "patterns": [
                 {
@@ -891,8 +894,11 @@
                 }
               ]
             },
-            "6": {
+            "7": {
               "name": "punctuation.separator.asciidoc"
+            },
+            "8": {
+              "name": "meta.trailing-whitespace.asciidoc"
             }
           }
         }


### PR DESCRIPTION
## Summary

Block macros (e.g. \image::path[]\, \include::file[]\) were matched by \#general-block-macro\ with a pattern anchored as \^...(macro)...\$\. The entire line had to be exactly the macro with no leading or trailing whitespace. Adding even one space (e.g. to put multiple block images on one line or to satisfy a formatter) caused the pattern not to match, so syntax highlighting was lost—only the brackets stayed highlighted.

This change relaxes the pattern to \^(\s*)(macro)(\s*)\$\ and adds capture groups for the optional leading/trailing whitespace so that the existing scope names for macro name, colons, target, and brackets are preserved (captures 2–7). Captures 1 and 8 scope the optional whitespace as \meta.leading-whitespace\ / \meta.trailing-whitespace\.

## Related

- Tracks behavior reported in image-macro whitespace / syntax-highlight issues (e.g. [.issues](https://github.com/AMDphreak/.issues) \sciidoc-vscode-image-macro-whitespace\).
- Inline form (\image:\) was already correct; this fixes **block** form (\image::\) and other block macros.

## Testing

1. Open an \.adoc\ file.
2. Add a line: \image::https://example.com/img.png[Alt]\ → macro name, \::\, URL, and \[Alt]\ are highlighted.
3. Add one space after \]\ (or before \image\) → highlighting is preserved (previously only brackets remained).


Made with [Cursor](https://cursor.com)