### PR TITLE
fix(vscode): explicit F5 build tasks and CONTRIBUTING notes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,23 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "npm: dev",
+      "preLaunchTask": "dev",
+      "skipFiles": ["<node_internals>/**"],
+      "showAsyncStacks": true
+    },
+    {
+      "name": "Run Extension (only this extension)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--disable-extensions",
+        "--extensionDevelopmentPath=${workspaceFolder}",
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "dev",
       "skipFiles": ["<node_internals>/**"],
       "showAsyncStacks": true
     },
@@ -34,7 +50,7 @@
       "outFiles": [
         "${workspaceFolder}/dist/src/test/**/*.js"
       ],
-      "preLaunchTask": "npm: pretest"
+      "preLaunchTask": "pretest"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,9 +2,27 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "build",
+      "label": "dev",
       "type": "shell",
-      "command": "npm run dev"
+      "command": "npm run dev",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "pretest",
+      "type": "shell",
+      "command": "npm run pretest",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "build",
+      "problemMatcher": []
     }
   ]
 }

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -25,9 +25,47 @@ Before developing changes, install the following prerequisites:
 +
  $ npm install
 
++
+[NOTE]
+====
+If you use https://pnpm.io[pnpm] instead of npm (for example in a fork that sets `packageManager` in `package.json`), run `pnpm install` here instead. Script names in `package.json` stay the same. The checked-in `.vscode/tasks.json` uses `npm run` so the default flow matches this guide; you may change those commands to `pnpm run` locally if you prefer.
+====
+
 . Make changes (ideally on a separate branch).
 
 Testing is done differently on the desktop client and the web client.
+
+=== Run and Debug (F5) and the build task
+
+In the simplest terms:
+
+* Pressing *Run* > *Start Debugging* (or F5 with *Run Extension* selected) builds the extension, then launches a second VS Code window to try it.
+* The build step is wired through `.vscode/tasks.json` and `.vscode/launch.json` so it does not depend on editor-only “magic” task names.
+
+==== A bit more detail (what used to go wrong)
+
+For many years, `launch.json` pointed `preLaunchTask` at names like `npm: dev` and `npm: pretest`.
+
+Those strings are *not* npm script names from `package.json`.
+They are labels that Visual Studio Code’s *npm Scripts* integration *can* auto-generate when it scans `package.json` and that integration lists your scripts.
+
+That worked for some setups, but it was never defined in a checked-in `tasks.json` file—it depended on VS Code creating those tasks for you.
+
+If that integration does not register tasks under the `npm: …` names (for example when using another package manager, or when the Scripts view does not populate the same way), you can see an error such as `could not find the task 'npm: dev'` even though the `dev` script still exists in `package.json`.
+
+==== What we do instead
+
+The repository defines ordinary shell tasks in `.vscode/tasks.json` (labels `dev` and `pretest` that run `npm run dev` and `npm run pretest`).
+`launch.json` sets `preLaunchTask` to those same labels.
+
+That way, “press F5” always has a real task to run, independent of whether the implicit `npm: …` tasks appear.
+
+There is also a *Run Extension (only this extension)* configuration that passes `--disable-extensions` so the Extension Development Host does not load your other installed extensions; use it when you want a quieter Debug Console.
+
+==== Technical note (historical)
+
+In 2021, `launch.json` was updated to use `npm: dev`-style `preLaunchTask` values alongside script renames (`dev`, `pretest`).
+That matched the convention of the time; the mismatch with an explicit `tasks.json` (which used a different label, `build`) was easy to miss because the implicit tasks hid the gap.
 
 === Running the Desktop version
 


### PR DESCRIPTION
## Summary

This PR is intentionally **small**: it only fixes **Run Extension / F5** debugging and documents **why** the old `preLaunchTask` names failed for some setups.

- **`.vscode/tasks.json`** — Define real tasks `dev` and `pretest` that run `npm run dev` and `npm run pretest`, and wire **`launch.json`** `preLaunchTask` to those labels (instead of relying on implicit `npm: dev` / `npm: pretest` tasks from VS Code’s npm Scripts integration).
- **`.vscode/launch.json`** — Same wiring; add **Run Extension (only this extension)** (`--disable-extensions`) for a quieter Extension Development Host when debugging.
- **`CONTRIBUTING.adoc`** — Explain the above in plain language first, then more detail. **npm** remains the default (`npm install`, `npm t`, web test command unchanged). A short **NOTE** mentions **pnpm** for forks that use it—**additional**, not a replacement.

No build-script refactors, no merge from other topic branches, and no change to default npm-oriented contributor flow.

## Plain language

When you press F5, VS Code runs a build task first. The repo used to reference task names like `npm: dev`. Those are **not** script names in `package.json`; they are labels VS Code **may** auto-create. If they are missing, you get `could not find the task 'npm: dev'`. Explicit tasks in `tasks.json` fix that.

## Reviewer detail

The `npm: <script>` pattern came from a **2021** `launch.json` update; checked-in `tasks.json` used a different label (`build`), so the mismatch was easy to miss until implicit tasks disappear (e.g. some package-manager setups).
