### PR TITLE
fix: use fsPath to generate correct windows paths

### DIFF
--- a/src/features/asciidoctorAttributesConfig.ts
+++ b/src/features/asciidoctorAttributesConfig.ts
@@ -8,7 +8,9 @@ export class AsciidoctorAttributesConfig {
       null,
     )
     const attributes = asciidocPreviewConfig.get('asciidoctorAttributes', {})
-    const workspacePath = findDefaultWorkspaceFolderUri()?.path
+    const workspacePath = vscode.env.uiKind === vscode.UIKind.Desktop
+      ? findDefaultWorkspaceFolderUri()?.fsPath
+      : findDefaultWorkspaceFolderUri()?.path
     Object.keys(attributes).forEach((key) => {
       const attributeValue = attributes[key]
       if (typeof attributeValue === 'string') {

--- a/src/features/asciidoctorConfig.ts
+++ b/src/features/asciidoctorConfig.ts
@@ -103,12 +103,11 @@ export async function getAsciidoctorConfigContent(
     const asciidoctorConfigContent = new TextDecoder().decode(
       await vscode.workspace.fs.readFile(asciidoctorConfig),
     )
-    const asciidoctorConfigParentDirectory = asciidoctorConfig.path.slice(
-      0,
-      asciidoctorConfig.path.lastIndexOf('/'),
-    )
+    const asciidoctorConfigParentUri = vscode.Uri.joinPath(asciidoctorConfig, '..')
+    const asciidoctorConfigDirectory = vscode.env.uiKind === vscode.UIKind.Desktop
+      ? asciidoctorConfigParentUri.fsPath : asciidoctorConfigParentUri.path
     configContents.push(
-      `:asciidoctorconfigdir: ${asciidoctorConfigParentDirectory}\n\n${asciidoctorConfigContent.trim()}\n\n`,
+      `:asciidoctorconfigdir: ${asciidoctorConfigDirectory}\n\n${asciidoctorConfigContent.trim()}\n\n`,
     )
   }
   if (configContents.length > 0) {


### PR DESCRIPTION
Fixes the windows path handling for the `asciidoctorconfigdir` attribute and `${workspaceFolder}` placeholder using the suggested implementation from https://github.com/asciidoctor/asciidoctor-vscode/issues/902#issuecomment-2352405978 and https://github.com/asciidoctor/asciidoctor-vscode/pull/978#issuecomment-3584732136.

Resolves #902
Resolves #897