### PR TITLE
chore(deps): upgrade TypeScript from 4.9.5 to 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "path-browserify": "1.0.1",
         "semver": "^7.3.7",
         "sinon": "^14.0.1",
-        "typescript": "4.9.5",
+        "typescript": "^5.9.3",
         "vscode-tmgrammar-test": "^0.1.3"
       },
       "engines": {
@@ -6178,16 +6178,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -655,7 +655,7 @@
     "path-browserify": "1.0.1",
     "semver": "^7.3.7",
     "sinon": "^14.0.1",
-    "typescript": "4.9.5",
+    "typescript": "^5.9.3",
     "vscode-tmgrammar-test": "^0.1.3"
   },
   "dependencies": {

--- a/src/features/builtinDocumentAttributeProvider.ts
+++ b/src/features/builtinDocumentAttributeProvider.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
-import builtinAttributes from './builtinDocumentAttribute.json'
+import builtinAttributes from './builtinDocumentAttribute.json' with {
+  type: 'json',
+}
 
 export class BuiltinDocumentAttributeProvider {
   private readonly completionItems = Object.keys(builtinAttributes).map(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "module": "es2022",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "es2022",
     "outDir": "dist",


### PR DESCRIPTION
Required to fix type errors from @types/d3-dispatch@3.0.7 (pulled in by mermaid) which uses const type parameters, a TypeScript 5.0+ feature.

- Set module to "NodeNext" to match moduleResolution (now enforced by TS5)
- Add import attribute `with { type: 'json' }` to JSON import (required by TS5 + NodeNext)
