### PR TITLE
fix(grammar): support dots delimiter in listing-paragraph

### DIFF
--- a/syntaxes/asciidoc.tmLanguage.base.json
+++ b/syntaxes/asciidoc.tmLanguage.base.json
@@ -1566,6 +1566,11 @@
               "end": "^(\\1)$"
             },
             {
+              "comment": "literal block",
+              "begin": "^(\\.{4,})\\s*$",
+              "end": "^(\\1)$"
+            },
+            {
               "comment": "open block",
               "begin": "^(-{2})\\s*$",
               "end": "^(\\1)$"
@@ -1574,7 +1579,7 @@
               "include": "#inlines"
             }
           ],
-          "end": "((?<=--)$|^\\p{Blank}*$)"
+          "end": "((?<=--|\\.\\.)$|^\\p{Blank}*$)"
         }
       ]
     },

--- a/syntaxes/asciidoc.tmLanguage.json
+++ b/syntaxes/asciidoc.tmLanguage.json
@@ -1572,6 +1572,11 @@
               "end": "^(\\1)$"
             },
             {
+              "comment": "literal block",
+              "begin": "^(\\.{4,})\\s*$",
+              "end": "^(\\1)$"
+            },
+            {
               "comment": "open block",
               "begin": "^(-{2})\\s*$",
               "end": "^(\\1)$"
@@ -1580,7 +1585,7 @@
               "include": "#inlines"
             }
           ],
-          "end": "((?<=--)$|^\\p{Blank}*$)"
+          "end": "((?<=--|\\.\\.)$|^\\p{Blank}*$)"
         }
       ]
     },

--- a/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-input.adoc
+++ b/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-input.adoc
@@ -1,0 +1,8 @@
+[listing]
+....
+content
+....
+
+////
+block comment
+////

--- a/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-input.adoc.snap
+++ b/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-input.adoc.snap
@@ -1,0 +1,18 @@
+>[listing]
+#^ text.asciidoc markup.block.listing.asciidoc
+# ^^^^^^^ text.asciidoc markup.block.listing.asciidoc markup.meta.attribute-list.asciidoc entity.name.function.asciidoc
+#        ^ text.asciidoc markup.block.listing.asciidoc
+>....
+#^^^^^ text.asciidoc markup.block.listing.asciidoc
+>content
+#^^^^^^^^ text.asciidoc markup.block.listing.asciidoc
+>....
+#^^^^ text.asciidoc markup.block.listing.asciidoc
+>
+>////
+#^^^^ text.asciidoc comment.block.asciidoc
+>block comment
+#^^^^^^^^^^^^^^ text.asciidoc comment.block.asciidoc
+>////
+#^^^^ text.asciidoc comment.block.asciidoc
+>

--- a/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-inside-example-block-input.adoc
+++ b/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-inside-example-block-input.adoc
@@ -1,0 +1,31 @@
+.This is a dash listing because it contains dots
+====
+[listing]
+----
+
+A sequence of dots:
+
+....................
+
+----
+====
+
+////
+This is a block comment.
+////
+
+.This is a dot listing because it contains dashes
+====
+[listing]
+....
+
+A sequence of dashes:
+
+--------------------
+
+....
+====
+
+////
+This is another block comment.
+////

--- a/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-inside-example-block-input.adoc.snap
+++ b/syntaxes/tests/snap/block/listing/listing-style-with-dots-delimiter-inside-example-block-input.adoc.snap
@@ -1,0 +1,60 @@
+>.This is a dash listing because it contains dots
+#^ text.asciidoc
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.asciidoc markup.heading.blocktitle.asciidoc
+>====
+#^^^^ text.asciidoc markup.block.example.asciidoc
+>[listing]
+#^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+# ^^^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc markup.meta.attribute-list.asciidoc entity.name.function.asciidoc
+#        ^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>----
+#^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>
+>A sequence of dots:
+#^^^^^^^^^^^^^^^^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>
+>....................
+#^^^^^^^^^^^^^^^^^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>
+>----
+#^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>====
+#^^^^ text.asciidoc markup.block.example.asciidoc
+>
+>////
+#^^^^ text.asciidoc comment.block.asciidoc
+>This is a block comment.
+#^^^^^^^^^^^^^^^^^^^^^^^^^ text.asciidoc comment.block.asciidoc
+>////
+#^^^^ text.asciidoc comment.block.asciidoc
+>
+>.This is a dot listing because it contains dashes
+#^ text.asciidoc
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.asciidoc markup.heading.blocktitle.asciidoc
+>====
+#^^^^ text.asciidoc markup.block.example.asciidoc
+>[listing]
+#^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+# ^^^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc markup.meta.attribute-list.asciidoc entity.name.function.asciidoc
+#        ^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>....
+#^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>
+>A sequence of dashes:
+#^^^^^^^^^^^^^^^^^^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>
+>--------------------
+#^^^^^^^^^^^^^^^^^^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>
+>....
+#^^^^ text.asciidoc markup.block.example.asciidoc markup.block.listing.asciidoc
+>====
+#^^^^ text.asciidoc markup.block.example.asciidoc
+>
+>////
+#^^^^ text.asciidoc comment.block.asciidoc
+>This is another block comment.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.asciidoc comment.block.asciidoc
+>////
+#^^^^ text.asciidoc comment.block.asciidoc
+>


### PR DESCRIPTION
A [listing] block using `....` delimiters was not recognized correctly. The grammar only handled dash delimiters (`----`), causing the closing `....` to be misidentified as a new literal-paragraph that swallowed subsequent content, breaking syntax highlighting for block comments.

Fixes #439
