### PR TITLE
feat(grammar): update list and monospace scopes, add snapshot tests

### DIFF
--- a/src/features/preview/asciidoctorWebViewConverter.ts
+++ b/src/features/preview/asciidoctorWebViewConverter.ts
@@ -179,7 +179,6 @@ export class AsciidoctorWebViewConverter {
    * @returns           Converted node
    */
   async convert(node, transform) {
-    console.log({ node })
     const nodeName = transform || node.getNodeName()
     if (nodeName === 'document') {
       // Content Security Policy

--- a/syntaxes/asciidoc.tmLanguage.base.json
+++ b/syntaxes/asciidoc.tmLanguage.base.json
@@ -529,31 +529,31 @@
       "patterns": [
         {
           "match": "^\\s*(-)\\p{Blank}(\\[[\\p{Blank}\\*x]\\])(?=\\p{Blank})",
-          "name": "markup.todo.asciidoc",
+          "name": "markup.list.todo.asciidoc",
           "captures": {
-            "1": {
-              "name": "markup.list.bullet.asciidoc"
+            "0": {
+              "name": "punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown"
             },
-            "2": {
-              "name": "markup.todo.box.asciidoc"
+            "1": {
+              "name": "punctuation.definition.metadata.asciidoc punctuation.definition.metadata.markdown"
             }
           }
         },
         {
-          "name": "markup.list.asciidoc",
+          "name": "markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown",
           "match": "^\\p{Blank}*(-|\\*{1,5}|\\u2022{1,5})(?=\\p{Blank})",
           "captures": {
-            "1": {
-              "name": "markup.list.bullet.asciidoc"
+            "0": {
+              "name": "punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown"
             }
           }
         },
         {
-          "name": "markup.list.asciidoc",
+          "name": "markup.list.numbered.asciidoc markup.list.numbered.markdown",
           "match": "^\\p{Blank}*(\\.{1,5}|\\d+\\.|[a-zA-Z]\\.|[IVXivx]+\\))(?=\\p{Blank})",
           "captures": {
-            "1": {
-              "name": "markup.list.bullet.asciidoc"
+            "0": {
+              "name": "punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown"
             }
           }
         },
@@ -1086,7 +1086,7 @@
               "name": "markup.meta.attribute-list.asciidoc"
             },
             "2": {
-              "name": "markup.raw.monospace.asciidoc"
+              "name": "markup.inline.raw.monospace.asciidoc"
             },
             "3": {
               "name": "punctuation.definition.asciidoc"
@@ -1104,7 +1104,7 @@
               "name": "markup.meta.attribute-list.asciidoc"
             },
             "2": {
-              "name": "markup.raw.monospace.asciidoc"
+              "name": "markup.inline.raw.monospace.asciidoc"
             },
             "3": {
               "name": "punctuation.definition.asciidoc"

--- a/syntaxes/asciidoc.tmLanguage.json
+++ b/syntaxes/asciidoc.tmLanguage.json
@@ -535,31 +535,31 @@
       "patterns": [
         {
           "match": "^\\s*(-)\\p{Blank}(\\[[\\p{Blank}\\*x]\\])(?=\\p{Blank})",
-          "name": "markup.todo.asciidoc",
+          "name": "markup.list.todo.asciidoc",
           "captures": {
-            "1": {
-              "name": "markup.list.bullet.asciidoc"
+            "0": {
+              "name": "punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown"
             },
-            "2": {
-              "name": "markup.todo.box.asciidoc"
+            "1": {
+              "name": "punctuation.definition.metadata.asciidoc punctuation.definition.metadata.markdown"
             }
           }
         },
         {
-          "name": "markup.list.asciidoc",
+          "name": "markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown",
           "match": "^\\p{Blank}*(-|\\*{1,5}|\\u2022{1,5})(?=\\p{Blank})",
           "captures": {
-            "1": {
-              "name": "markup.list.bullet.asciidoc"
+            "0": {
+              "name": "punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown"
             }
           }
         },
         {
-          "name": "markup.list.asciidoc",
+          "name": "markup.list.numbered.asciidoc markup.list.numbered.markdown",
           "match": "^\\p{Blank}*(\\.{1,5}|\\d+\\.|[a-zA-Z]\\.|[IVXivx]+\\))(?=\\p{Blank})",
           "captures": {
-            "1": {
-              "name": "markup.list.bullet.asciidoc"
+            "0": {
+              "name": "punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown"
             }
           }
         },
@@ -1092,7 +1092,7 @@
               "name": "markup.meta.attribute-list.asciidoc"
             },
             "2": {
-              "name": "markup.raw.monospace.asciidoc"
+              "name": "markup.inline.raw.monospace.asciidoc"
             },
             "3": {
               "name": "punctuation.definition.asciidoc"
@@ -1110,7 +1110,7 @@
               "name": "markup.meta.attribute-list.asciidoc"
             },
             "2": {
-              "name": "markup.raw.monospace.asciidoc"
+              "name": "markup.inline.raw.monospace.asciidoc"
             },
             "3": {
               "name": "punctuation.definition.asciidoc"

--- a/syntaxes/tests/snap/block/list/checklist-input.adoc
+++ b/syntaxes/tests/snap/block/list/checklist-input.adoc
@@ -1,0 +1,4 @@
+- [*] checked
+- [x] also checked
+- [ ] not checked
+- normal list item

--- a/syntaxes/tests/snap/block/list/checklist-input.adoc.snap
+++ b/syntaxes/tests/snap/block/list/checklist-input.adoc.snap
@@ -1,0 +1,15 @@
+>- [*] checked
+#^ text.asciidoc markup.list.todo.asciidoc punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown punctuation.definition.metadata.asciidoc punctuation.definition.metadata.markdown
+# ^^^^ text.asciidoc markup.list.todo.asciidoc punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#     ^^^^^^^^^ text.asciidoc
+>- [x] also checked
+#^ text.asciidoc markup.list.todo.asciidoc punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown punctuation.definition.metadata.asciidoc punctuation.definition.metadata.markdown
+# ^^^^ text.asciidoc markup.list.todo.asciidoc punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#     ^^^^^^^^^^^^^^ text.asciidoc
+>- [ ] not checked
+#^ text.asciidoc markup.list.todo.asciidoc punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown punctuation.definition.metadata.asciidoc punctuation.definition.metadata.markdown
+# ^^^^ text.asciidoc markup.list.todo.asciidoc punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#     ^^^^^^^^^^^^^ text.asciidoc
+>- normal list item
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^^^ text.asciidoc

--- a/syntaxes/tests/snap/block/list/ordered-auto-input.adoc
+++ b/syntaxes/tests/snap/block/list/ordered-auto-input.adoc
@@ -1,0 +1,3 @@
+. Protons
+. Electrons
+. Neutrons

--- a/syntaxes/tests/snap/block/list/ordered-auto-input.adoc.snap
+++ b/syntaxes/tests/snap/block/list/ordered-auto-input.adoc.snap
@@ -1,0 +1,9 @@
+>. Protons
+#^ text.asciidoc markup.list.numbered.asciidoc markup.list.numbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^ text.asciidoc
+>. Electrons
+#^ text.asciidoc markup.list.numbered.asciidoc markup.list.numbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^ text.asciidoc
+>. Neutrons
+#^ text.asciidoc markup.list.numbered.asciidoc markup.list.numbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^ text.asciidoc

--- a/syntaxes/tests/snap/block/list/ordered-input.adoc
+++ b/syntaxes/tests/snap/block/list/ordered-input.adoc
@@ -1,0 +1,3 @@
+1. Protons
+2. Electrons
+3. Neutrons

--- a/syntaxes/tests/snap/block/list/ordered-input.adoc.snap
+++ b/syntaxes/tests/snap/block/list/ordered-input.adoc.snap
@@ -1,0 +1,9 @@
+>1. Protons
+#^^ text.asciidoc markup.list.numbered.asciidoc markup.list.numbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#  ^^^^^^^^^ text.asciidoc
+>2. Electrons
+#^^ text.asciidoc markup.list.numbered.asciidoc markup.list.numbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#  ^^^^^^^^^^^ text.asciidoc
+>3. Neutrons
+#^^ text.asciidoc markup.list.numbered.asciidoc markup.list.numbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#  ^^^^^^^^^^ text.asciidoc

--- a/syntaxes/tests/snap/block/list/unordered-alt-input.adoc
+++ b/syntaxes/tests/snap/block/list/unordered-alt-input.adoc
@@ -1,0 +1,3 @@
+- Edgar Allan Poe
+- Sheri S. Tepper
+- Bill Bryson

--- a/syntaxes/tests/snap/block/list/unordered-alt-input.adoc.snap
+++ b/syntaxes/tests/snap/block/list/unordered-alt-input.adoc.snap
@@ -1,0 +1,9 @@
+>- Edgar Allan Poe
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^^ text.asciidoc
+>- Sheri S. Tepper
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^^ text.asciidoc
+>- Bill Bryson
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^ text.asciidoc

--- a/syntaxes/tests/snap/block/list/unordered-input.adoc
+++ b/syntaxes/tests/snap/block/list/unordered-input.adoc
@@ -1,0 +1,3 @@
+* Edgar Allan Poe
+* Sheri S. Tepper
+* Bill Bryson

--- a/syntaxes/tests/snap/block/list/unordered-input.adoc.snap
+++ b/syntaxes/tests/snap/block/list/unordered-input.adoc.snap
@@ -1,0 +1,9 @@
+>* Edgar Allan Poe
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^^ text.asciidoc
+>* Sheri S. Tepper
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^^ text.asciidoc
+>* Bill Bryson
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^ text.asciidoc

--- a/syntaxes/tests/snap/block/list/unordered-nested-input.adoc
+++ b/syntaxes/tests/snap/block/list/unordered-nested-input.adoc
@@ -1,0 +1,5 @@
+* West wood maze
+** Maze heart
+*** Reflection pool
+** Secret exit
+* Untracked file in git repository

--- a/syntaxes/tests/snap/block/list/unordered-nested-input.adoc.snap
+++ b/syntaxes/tests/snap/block/list/unordered-nested-input.adoc.snap
@@ -1,0 +1,15 @@
+>* West wood maze
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^ text.asciidoc
+>** Maze heart
+#^^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#  ^^^^^^^^^^^^ text.asciidoc
+>*** Reflection pool
+#^^^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#   ^^^^^^^^^^^^^^^^^ text.asciidoc
+>** Secret exit
+#^^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+#  ^^^^^^^^^^^^^ text.asciidoc
+>* Untracked file in git repository
+#^ text.asciidoc markup.list.unnumbered.asciidoc markup.list.unnumbered.markdown punctuation.definition.list.begin.asciidoc punctuation.definition.list.begin.markdown
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.asciidoc

--- a/syntaxes/tests/snap/inline/monospace/constrained-input.adoc
+++ b/syntaxes/tests/snap/inline/monospace/constrained-input.adoc
@@ -1,0 +1,1 @@
+`E=mc^2^`; the `E` represents _energy_, but also pure _genius!_

--- a/syntaxes/tests/snap/inline/monospace/constrained-input.adoc.snap
+++ b/syntaxes/tests/snap/inline/monospace/constrained-input.adoc.snap
@@ -1,0 +1,16 @@
+>`E=mc^2^`; the `E` represents _energy_, but also pure _genius!_
+#^ text.asciidoc markup.monospace.constrained.asciidoc markup.inline.raw.monospace.asciidoc punctuation.definition.asciidoc
+# ^^^^^^^ text.asciidoc markup.monospace.constrained.asciidoc markup.inline.raw.monospace.asciidoc
+#        ^ text.asciidoc markup.monospace.constrained.asciidoc markup.inline.raw.monospace.asciidoc punctuation.definition.asciidoc
+#         ^^^^^^ text.asciidoc
+#               ^ text.asciidoc markup.monospace.constrained.asciidoc markup.inline.raw.monospace.asciidoc punctuation.definition.asciidoc
+#                ^ text.asciidoc markup.monospace.constrained.asciidoc markup.inline.raw.monospace.asciidoc
+#                 ^ text.asciidoc markup.monospace.constrained.asciidoc markup.inline.raw.monospace.asciidoc punctuation.definition.asciidoc
+#                  ^^^^^^^^^^^^ text.asciidoc
+#                              ^ text.asciidoc markup.emphasis.constrained.asciidoc markup.italic.asciidoc punctuation.definition.asciidoc
+#                               ^^^^^^ text.asciidoc markup.emphasis.constrained.asciidoc markup.italic.asciidoc
+#                                     ^ text.asciidoc markup.emphasis.constrained.asciidoc markup.italic.asciidoc punctuation.definition.asciidoc
+#                                      ^^^^^^^^^^^^^^^^ text.asciidoc
+#                                                      ^ text.asciidoc markup.emphasis.constrained.asciidoc markup.italic.asciidoc punctuation.definition.asciidoc
+#                                                       ^^^^^^^ text.asciidoc markup.emphasis.constrained.asciidoc markup.italic.asciidoc
+#                                                              ^ text.asciidoc markup.emphasis.constrained.asciidoc markup.italic.asciidoc punctuation.definition.asciidoc

--- a/syntaxes/tests/snap/inline/monospace/unconstrained-input.adoc
+++ b/syntaxes/tests/snap/inline/monospace/unconstrained-input.adoc
@@ -1,0 +1,1 @@
+The command will re``link`` all packages.

--- a/syntaxes/tests/snap/inline/monospace/unconstrained-input.adoc.snap
+++ b/syntaxes/tests/snap/inline/monospace/unconstrained-input.adoc.snap
@@ -1,0 +1,6 @@
+>The command will re``link`` all packages.
+#^^^^^^^^^^^^^^^^^^^ text.asciidoc
+#                   ^^ text.asciidoc markup.monospace.unconstrained.asciidoc markup.inline.raw.monospace.asciidoc punctuation.definition.asciidoc
+#                     ^^^^ text.asciidoc markup.monospace.unconstrained.asciidoc markup.inline.raw.monospace.asciidoc
+#                         ^^ text.asciidoc markup.monospace.unconstrained.asciidoc markup.inline.raw.monospace.asciidoc punctuation.definition.asciidoc
+#                           ^^^^^^^^^^^^^^^ text.asciidoc


### PR DESCRIPTION
Use double scopes on list patterns (e.g. markup.list.unnumbered.asciidoc + markup.list.unnumbered.markdown) so default themes apply colors via the .markdown prefix while users can target the precise .asciidoc scope for customization.

Add snapshot tests for unordered, ordered, nested, checklist lists and inline monospace (constrained/unconstrained).

<img width="474" height="632" alt="Capture d’écran 2026-05-24 à 22 37 32" src="https://github.com/user-attachments/assets/d93ee459-29d3-45af-966d-cde3de986171" />

<img width="474" height="632" alt="Capture d’écran 2026-05-24 à 22 37 07" src="https://github.com/user-attachments/assets/e31d0ed4-e943-4281-a0b7-e0122c4870c8" />

