### PR TITLE
docs: add AsciiDoc Editor Specification

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,3 +13,4 @@ asciidoc:
     url-vscode-web: https://code.visualstudio.com/docs/editor/vscode-web
 nav:
 - modules/ROOT/nav.adoc
+- modules/spec/nav.adoc

--- a/docs/modules/spec/nav.adoc
+++ b/docs/modules/spec/nav.adoc
@@ -1,0 +1,13 @@
+.AsciiDoc Editor Specification
+* xref:spec:outline.adoc[Overview]
+* xref:spec:language-support.adoc[Language Support]
+* xref:spec:editing.adoc[Editing]
+* xref:spec:text-folding.adoc[Text Folding]
+* xref:spec:navigation.adoc[Navigation]
+* xref:spec:diagnostics.adoc[Diagnostics & Validation]
+* xref:spec:preview.adoc[Preview]
+* xref:spec:diagrams.adoc[Diagram Integration]
+* xref:spec:export.adoc[Export]
+* xref:spec:refactoring.adoc[Refactoring]
+* xref:spec:configuration.adoc[Configuration]
+* xref:spec:antora.adoc[Antora Integration]

--- a/docs/modules/spec/pages/antora.adoc
+++ b/docs/modules/spec/pages/antora.adoc
@@ -1,0 +1,85 @@
+= Antora Integration
+
+== Overview
+
+https://antora.org[Antora] is the multi-repository documentation site generator for AsciiDoc. Editors with Antora support enable accurate cross-reference resolution, attribute injection, and path completion for Antora component structures.
+
+== Project Detection
+
+An editor SHOULD automatically detect Antora projects by looking for `antora.yml` files combined with the standard `modules/` directory structure.
+
+An editor SHOULD also detect Antora playbook files by common naming conventions (e.g., `antora-playbook.yml`, `site.yml`).
+
+An editor MUST NOT activate Antora-specific behaviors in non-Antora projects.
+An editor SHOULD provide a user-facing toggle to enable or disable Antora support per workspace.
+An editor SHOULD prompt the author to enable Antora support when an Antora project is first detected.
+
+== Attribute Resolution
+
+When Antora support is active, an editor MUST resolve document attributes from `antora.yml` component and module descriptors, including:
+
+* Component-level attributes defined in `antora.yml` under `asciidoc.attributes`
+* Module-level attributes (where supported by Antora)
+* Automatically generated Antora page attributes: `{page-component-name}`, `{page-component-version}`, `{page-module}`, `{page-relative-src-path}`, `{page-origin-url}`, etc.
+* Directory attributes: `{imagesdir}`, `{partialsdir}`, `{examplesdir}`, `{attachmentsdir}`
+
+== Cross-Reference Resolution
+
+An editor MUST resolve Antora cross-references (`xref:`) using the full Antora coordinates syntax:
+
+----
+xref:version@component:module:page.adoc#anchor[text]
+----
+
+All coordinate segments are optional; an editor MUST apply Antora's default resolution rules for omitted segments.
+
+An editor MUST support cross-references targeting all Antora file families:
+
+* `page$` (default) — navigable pages
+* `partial$` — included partial files
+* `example$` — example files
+* `attachment$` — downloadable attachments
+
+An editor SHOULD validate cross-references and highlight any that cannot be resolved within the detected Antora project structure.
+
+== Auto-Completion
+
+An editor SHOULD provide auto-completion (triggered by `xref:` or `<<`) for:
+
+* Component names found in the workspace
+* Module names within a component
+* Page and partial file names within a module
+* Anchor IDs within pages
+
+An editor SHOULD also complete `include::` paths using Antora family coordinates (e.g., `partial$`, `example$`).
+
+== Include Path Resolution
+
+An editor MUST resolve `include::` directives using Antora's resource ID syntax, for example:
+
+----
+\include::partial$common-attributes.adoc[]
+\include::version@component:module:partial$shared.adoc[]
+----
+
+== Preview Integration
+
+When Antora support is active, an editor SHOULD apply the Antora UI theme (or a reasonable approximation) to the preview, including:
+
+* Antora-bundled stylesheets
+* Light/dark mode support where the theme provides it
+
+== Multi-Repository Support
+
+An editor SHOULD support workspaces that contain multiple Antora components across separate Git repositories.
+
+In multi-repository workspaces, cross-reference completion and validation MUST span all detected components.
+
+== Playbook Support
+
+An editor MAY parse the Antora playbook file (`antora-playbook.yml`) to discover content sources that are not present as local directories (e.g., remote Git repositories).
+When playbook-declared sources are not locally available, the editor SHOULD gracefully degrade by disabling completion and validation for those sources without breaking support for locally available content.
+
+== JSON Schema Validation
+
+An editor SHOULD validate `antora.yml` and Antora playbook YAML files against their respective JSON Schemas, providing inline diagnostics for invalid or missing required fields.

--- a/docs/modules/spec/pages/antora.adoc
+++ b/docs/modules/spec/pages/antora.adoc
@@ -14,6 +14,13 @@ An editor MUST NOT activate Antora-specific behaviors in non-Antora projects.
 An editor SHOULD provide a user-facing toggle to enable or disable Antora support per workspace.
 An editor SHOULD prompt the author to enable Antora support when an Antora project is first detected.
 
+When prompting to enable Antora support, an editor SHOULD:
+
+* Show at most one prompt at a time, rather than stacking one prompt per opened document
+* Treat dismissing the prompt (without answering) as "not now" — it stops prompting for the current session without disabling Antora support, so the question MAY be asked again in a later session
+* Offer a way to permanently decline (e.g., a "Never" choice) that is persisted and stops the editor from prompting again
+* Honour a decision made meanwhile through the enable/disable command instead of asking again
+
 == Attribute Resolution
 
 When Antora support is active, an editor MUST resolve document attributes from `antora.yml` component and module descriptors, including:
@@ -61,6 +68,16 @@ An editor MUST resolve `include::` directives using Antora's resource ID syntax,
 \include::partial$common-attributes.adoc[]
 \include::version@component:module:partial$shared.adoc[]
 ----
+
+== Image Insertion
+
+When Antora support is active, an editor inserting an image (via drag-and-drop or clipboard paste) MUST reference the image within the page's module image family rather than by a document-relative path.
+
+An editor SHOULD:
+
+* Reference an image that already lives in the module's `images` directory by its bare name, without copying it
+* Offer to copy an external image into the module's `images` directory and then reference it by its bare name
+* Suppress document-relative "insert path" options that would not resolve under Antora's resource resolution
 
 == Preview Integration
 

--- a/docs/modules/spec/pages/configuration.adoc
+++ b/docs/modules/spec/pages/configuration.adoc
@@ -1,0 +1,81 @@
+= Configuration
+
+== Asciidoctor Config File
+
+An editor MUST support the `.asciidoctorconfig` file convention for project-level Asciidoctor configuration.
+
+=== File Naming
+
+An editor MUST recognize both of the following file names:
+
+* `.asciidoctorconfig`
+* `.asciidoctorconfig.adoc`
+
+=== Location and Scope
+
+An editor MUST look for `.asciidoctorconfig` files in the following locations and apply them to the document being rendered:
+
+* The workspace root directory
+* Every directory on the path from the workspace root to the directory containing the document
+
+When multiple `.asciidoctorconfig` files are found, an editor MUST apply them in order from the outermost (workspace root) to the innermost (document's directory), with inner files taking precedence over outer files.
+
+=== Content
+
+`.asciidoctorconfig` files MUST be processed as AsciiDoc header fragments.
+They SHOULD support:
+
+* Document attribute declarations (`:[name]: value`)
+* `include::` directives
+* `ifdef::` / `ifndef::` / `ifeval::` / `endif::` preprocessor directives
+
+An editor implementing `.asciidoctorconfig` SHOULD expose a built-in `{asciidoctorconfigdir}` attribute that resolves to the directory containing the config file, so that relative include paths within the config file work correctly regardless of where the document being edited is located.
+
+=== IDE-Agnostic Convention
+
+The `.asciidoctorconfig` convention SHOULD be treated as an open standard.
+Implementations across different IDEs and editors SHOULD behave consistently to enable portability of project-level configuration.
+
+== Custom Asciidoctor Extensions
+
+An editor MAY support loading custom Asciidoctor extensions for use in the preview renderer.
+
+=== Extension Location
+
+An editor implementing custom extension support MUST load extensions from the `.asciidoctor/lib/` directory at the workspace root.
+
+=== Extension Types
+
+* **Ruby extensions** (`.rb` files) loaded via the standard Asciidoctor extension API
+* **AsciidoctorJ extensions** (JAR files with a Java service loader entry) where a JVM runtime is available
+
+=== Trust and Security
+
+An editor MUST NOT load extensions automatically without explicit user consent, as extensions run with the same privileges as the IDE process.
+
+An editor SHOULD implement a per-workspace trust model:
+
+* First encounter: prompt the user to trust or decline extensions in the workspace
+* Trusted workspaces: load extensions automatically on subsequent opens
+* Untrusted workspaces: skip extension loading and notify the user
+
+An editor SHOULD display a clear warning explaining the security implications before granting extension trust.
+
+== Safe Mode
+
+An editor SHOULD allow configuring the Asciidoctor safe mode used during preview rendering.
+Supported values (in increasing restriction order): `UNSAFE`, `SERVER`, `SAFE`, `SECURE`.
+
+An editor SHOULD default to `SAFE` mode for preview rendering.
+
+== Workspace Settings
+
+An editor SHOULD provide a settings UI or configuration file for the following categories:
+
+* Preview behavior (refresh interval, stylesheet, scroll sync, security level)
+* PDF export (engine selection, custom command path and arguments)
+* Extension loading (enable/disable, trusted workspaces)
+* Antora support (enable/disable, auto-detect)
+* Debug and trace logging
+
+An editor SHOULD support both user-level and workspace-level settings, with workspace settings taking precedence over user settings.

--- a/docs/modules/spec/pages/configuration.adoc
+++ b/docs/modules/spec/pages/configuration.adoc
@@ -49,6 +49,18 @@ An editor implementing custom extension support MUST load extensions from the `.
 * **Ruby extensions** (`.rb` files) loaded via the standard Asciidoctor extension API
 * **AsciidoctorJ extensions** (JAR files with a Java service loader entry) where a JVM runtime is available
 
+=== Host-Editor Extension Contributions
+
+An editor MAY allow other plugins or extensions installed in the host editor to contribute Asciidoctor extensions programmatically (for example, a companion plugin that bundles a domain-specific extension), in addition to extensions discovered on disk.
+
+An editor implementing host-editor extension contributions SHOULD let a contributor scope each extension to the relevant processing modes:
+
+* `preview` — rendering the document for the live preview
+* `export` — converting the document for an export command (HTML, PDF, DocBook, …)
+* `load` — parsing the document for analysis (diagnostics, navigation, completion)
+
+An editor SHOULD isolate contribution failures so that a single failing contributor does not prevent the document from rendering, and SHOULD report the failure to the user.
+
 === Trust and Security
 
 An editor MUST NOT load extensions automatically without explicit user consent, as extensions run with the same privileges as the IDE process.

--- a/docs/modules/spec/pages/diagnostics.adoc
+++ b/docs/modules/spec/pages/diagnostics.adoc
@@ -1,0 +1,63 @@
+= Diagnostics & Validation
+
+== Asciidoctor Parser Diagnostics
+
+An editor MUST surface Asciidoctor parser errors and warnings as inline diagnostics in the editor.
+Each diagnostic MUST include:
+
+* Severity level (error or warning)
+* A human-readable message describing the problem
+* The file and line number where the problem was detected
+
+An editor SHOULD map Asciidoctor severity levels to editor severity levels:
+
+* `ERROR` → error diagnostic (red)
+* `WARN` → warning diagnostic (yellow)
+
+An editor SHOULD provide a way to navigate to the file and line referenced in include-related errors.
+
+An editor MAY allow authors to configure the severity mapping (e.g., demote errors to warnings).
+
+== Broken Reference Inspection
+
+An editor SHOULD highlight as warnings:
+
+* Cross-references (`xref:`, `<<>>`) pointing to non-existent anchors or section IDs
+* `include::` directives pointing to files that do not exist
+* `image::` and `image:` macros pointing to files that do not exist
+
+An editor MAY distinguish between missing files and missing anchors within existing files.
+
+== Deprecated Syntax Inspection
+
+An editor SHOULD warn about deprecated AsciiDoc constructs (e.g., two-colon include syntax variants, deprecated attribute names) and suggest the modern equivalent.
+
+== Spell Checking
+
+An editor SHOULD provide spell checking for prose content in AsciiDoc documents.
+
+Spell checking MUST NOT flag:
+
+* Markup syntax (macros, delimiters, attribute declarations)
+* Source code within `[source]` blocks
+* Passthrough content
+* Attribute names and values
+
+An editor SHOULD allow authors to configure which content categories are spell-checked (e.g., headings, list items, table cells, bold/italic text).
+
+An editor SHOULD allow adding words to a custom dictionary.
+
+== Grammar Checking
+
+An editor MAY provide grammar and style checking for AsciiDoc prose.
+
+Grammar checking MUST respect the same content exclusions as spell checking.
+Grammar checking SHOULD be configurable per AsciiDoc element type (e.g., apply only to headings and paragraph text).
+
+== Batch Validation
+
+An editor MAY provide a "run inspections" or "analyze project" action that validates all AsciiDoc files in the workspace and aggregates the results in a dedicated panel.
+
+== CI/CD Integration
+
+An editor MAY produce machine-readable validation reports (e.g., SARIF format) compatible with CI/CD pipelines and code scanning tools (e.g., GitHub Code Scanning, Qodana).

--- a/docs/modules/spec/pages/diagnostics.adoc
+++ b/docs/modules/spec/pages/diagnostics.adoc
@@ -32,6 +32,16 @@ An editor MAY distinguish between missing files and missing anchors within exist
 
 An editor SHOULD warn about deprecated AsciiDoc constructs (e.g., two-colon include syntax variants, deprecated attribute names) and suggest the modern equivalent.
 
+== Quick Fixes
+
+An editor SHOULD offer quick fixes (intention actions) attached to diagnostics where an automatic correction is possible, for example:
+
+* Creating the missing target file for a broken `include::` or `image::` reference
+* Replacing a deprecated construct with its modern equivalent
+* Adding an unknown word to the custom dictionary from a spelling diagnostic
+
+A quick fix MUST be undoable as a single action.
+
 == Spell Checking
 
 An editor SHOULD provide spell checking for prose content in AsciiDoc documents.

--- a/docs/modules/spec/pages/diagrams.adoc
+++ b/docs/modules/spec/pages/diagrams.adoc
@@ -1,0 +1,56 @@
+= Diagram Integration
+
+== Overview
+
+AsciiDoc documents commonly embed diagrams defined in textual domain-specific languages. An editor SHOULD render these diagrams in the live preview.
+
+== Kroki
+
+An editor SHOULD support the https://kroki.io[Kroki] diagram rendering service, which provides a unified API for over 30 diagram types, including:
+
+* PlantUML
+* Graphviz / DOT
+* Mermaid
+* BPMN
+* C4 (with PlantUML)
+* D2
+* Ditaa
+* Erd
+* Excalidraw
+* Nomnoml
+* Structurizr
+* Vega / Vega-Lite
+* WireViz
+
+An editor implementing Kroki support MUST allow authors to configure whether to use the public Kroki service or a self-hosted Kroki instance.
+An editor SHOULD allow configuring the Kroki server URL.
+
+== PlantUML
+
+An editor MAY support PlantUML diagram rendering using a locally installed PlantUML tool (or the Asciidoctor Diagram extension).
+An editor implementing local PlantUML SHOULD support Graphviz/DOT as a backend for class and component diagrams.
+
+== Mermaid
+
+An editor MAY support embedded Mermaid diagram rendering without requiring an external tool, using a bundled JavaScript Mermaid library.
+
+== Asciidoctor Diagram Extension
+
+An editor MAY support loading the Asciidoctor Diagram extension, which delegates rendering to locally installed tools.
+
+== SVG Interactivity
+
+An editor SHOULD preserve SVG interactivity features in the preview, including:
+
+* Hyperlinks within SVG diagrams
+* Hover effects
+* Pan and zoom (where supported by the SVG)
+
+== Diagram Download
+
+An editor MAY allow authors to save a rendered diagram as a PNG or SVG file from the preview.
+
+== Performance
+
+An editor SHOULD cache rendered diagrams to avoid re-rendering on every keystroke.
+An editor SHOULD render diagrams asynchronously so that editing is not blocked while diagrams are being generated.

--- a/docs/modules/spec/pages/editing.adoc
+++ b/docs/modules/spec/pages/editing.adoc
@@ -1,0 +1,130 @@
+= Editing
+
+== Auto-Completion
+
+=== Cross-Reference Completion
+
+An editor MUST provide auto-completion for cross-references using both syntaxes:
+
+* Shorthand syntax: `<<` triggers completion with available anchor IDs and section titles from the current document
+* Xref macro: `xref:` triggers completion with anchor IDs and section titles from all AsciiDoc files in the workspace
+
+An editor SHOULD resolve IDs defined via explicit anchors (`[[id]]`, `[id]`), auto-generated section title IDs, and anchors defined in included files.
+
+=== Include Path Completion
+
+An editor MUST provide path completion for `include::` directives, suggesting files relative to the current document's directory.
+
+An editor SHOULD scope suggestions based on the `:includedir:` or `:root:` document attributes when set.
+
+=== Image and Media Path Completion
+
+An editor MUST provide path completion for image and media macros:
+
+* `image::` (block) and `image:` (inline)
+* `video::` and `audio::`
+
+An editor SHOULD resolve paths relative to `:imagesdir:` when that attribute is defined in the document or in a `.asciidoctorconfig` file.
+
+=== Attribute Completion
+
+An editor MUST provide completion for attribute references (`{`), suggesting:
+
+* Attributes declared in the current document header
+* Attributes declared in `.asciidoctorconfig` files in the project
+
+An editor SHOULD also suggest built-in Asciidoctor attributes (e.g., `toc`, `doctype`, `imagesdir`, `source-highlighter`).
+
+=== BibTeX Citation Completion
+
+An editor MAY provide completion for citation macros (e.g., `cite:`, `citenp:`) by reading `.bib` files present in the workspace.
+
+== Snippets
+
+An editor SHOULD provide live templates or snippets for commonly used AsciiDoc constructs, including:
+
+* Document header template (title, author, revision line, common attributes)
+* Admonition blocks: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`
+* Block types: listing, literal, sidebar, quote, example, passthrough
+* `[source,lang]` block with language placeholder
+* `include::` directive
+* Block and inline `image::` / `image:` macros
+* `link:` and `mailto:` macros
+* Table skeleton (header row + data rows)
+* Callout list entry
+* Conditional blocks: `ifdef::[]`, `ifndef::[]`
+
+An editor MAY allow users to define and manage custom snippets.
+
+== Text Formatting Shortcuts
+
+An editor SHOULD provide keyboard shortcuts or auto-format triggers to apply inline formatting to selected text:
+
+* Bold: `*selected*`
+* Italic: `_selected_`
+* Monospace: `` `selected` ``
+* Highlight: `#selected#`
+* Subscript: `~selected~`
+* Superscript: `^selected^`
+* Passthrough: `+selected+`
+
+An editor MAY provide these actions via a toolbar in addition to keyboard shortcuts.
+
+== Smart Pairing
+
+An editor SHOULD automatically close the following delimiter pairs when typed:
+
+* `(` → `)`
+* `[` → `]`
+* `{` → `}`
+* `"` → `"`
+* `'` → `'`
+* `` ` `` → `` ` ``
+
+An editor SHOULD wrap selected text when one of the following characters is typed while text is selected: `*`, `_`, `` ` ``, `#`, `^`, `~`, `(`, `[`, `{`.
+
+== Comment Shortcuts
+
+An editor MUST support line comment toggling using `//` as the line comment prefix.
+An editor SHOULD support block comment toggling using `////` delimiters.
+
+== Image Insertion
+
+=== Drag and Drop
+
+An editor SHOULD support dragging image files from the file explorer into the editor to insert an `image::` macro with the correct relative path.
+
+=== Paste from Clipboard
+
+An editor SHOULD support pasting image data from the clipboard.
+When an image is pasted, the editor SHOULD:
+
+1. Prompt for or automatically generate a file name
+2. Save the image file to a configurable location (defaulting to `:imagesdir:` or the document directory)
+3. Insert an `image::` macro pointing to the saved file with a relative path
+
+=== Paste Formatted Text
+
+An editor MAY support converting HTML content on the clipboard to AsciiDoc markup when pasting (e.g., via Pandoc).
+
+== Reformat Document
+
+An editor SHOULD provide a "reformat document" action that:
+
+* Normalizes blank lines around headings and blocks (exactly one blank line before and after)
+* Normalizes list continuation markers
+* Optionally converts inline admonitions to block style
+
+An editor MAY support "one-sentence-per-line" reformatting as a code style option.
+
+== Table Generation
+
+An editor MAY provide a table builder UI or snippet that generates AsciiDoc table markup from user-specified dimensions (rows × columns).
+
+== Word Wrap
+
+An editor SHOULD enable soft word wrap by default for AsciiDoc files.
+
+== TODO/FIXME Indexing
+
+An editor MAY index `TODO` and `FIXME` markers in AsciiDoc comments and display them in a dedicated task or TODO view.

--- a/docs/modules/spec/pages/export.adoc
+++ b/docs/modules/spec/pages/export.adoc
@@ -1,0 +1,53 @@
+= Export
+
+== HTML Export
+
+An editor MUST provide an "Export as HTML" action that converts the current AsciiDoc document to a standalone HTML file using Asciidoctor.
+
+The generated HTML file MUST be self-contained (embedded CSS and assets where possible) or reference the Asciidoctor default stylesheet.
+An editor SHOULD allow configuring custom attributes and stylesheets for HTML export.
+An editor SHOULD open the generated HTML file in the system default browser upon completion.
+
+== PDF Export
+
+An editor SHOULD provide an "Export as PDF" action that converts the current AsciiDoc document to PDF.
+
+An editor implementing PDF export MUST support at least one of the following backends:
+
+* Asciidoctor PDF (`asciidoctor-pdf` gem or equivalent)
+* wkhtmltopdf (HTML-to-PDF via WebKit)
+
+An editor implementing PDF export SHOULD:
+
+* Allow configuring the path to the PDF generation tool
+* Allow passing additional command-line arguments
+* Allow selecting a PDF theme file (`:pdf-theme:`)
+* Open the generated PDF file in the system default PDF viewer upon completion
+
+An editor MAY support non-Latin character sets in PDF output by allowing custom font configuration (TTF fonts, per-language themes).
+
+== DOCX Export
+
+An editor MAY provide an "Export as DOCX" action using a two-step pipeline:
+
+1. AsciiDoc → DocBook 5 (via Asciidoctor)
+2. DocBook 5 → DOCX (via Pandoc)
+
+An editor implementing DOCX export SHOULD:
+
+* Allow specifying a `reference.docx` template file for styling
+* Open the generated DOCX file in the system default word processor upon completion
+
+== DocBook Export
+
+An editor MAY provide an "Export as DocBook" action that converts the document to DocBook 5 XML using Asciidoctor.
+
+== Export Configuration
+
+An editor SHOULD allow authors to configure per-workspace defaults for export actions:
+
+* Output directory
+* Asciidoctor attributes to pass during export
+* Backend selection
+
+An editor MAY persist export settings in a project-level configuration file.

--- a/docs/modules/spec/pages/export.adoc
+++ b/docs/modules/spec/pages/export.adoc
@@ -5,6 +5,7 @@
 An editor MUST provide an "Export as HTML" action that converts the current AsciiDoc document to a standalone HTML file using Asciidoctor.
 
 The generated HTML file MUST be self-contained (embedded CSS and assets where possible) or reference the Asciidoctor default stylesheet.
+An editor SHOULD honour the `:data-uri:` attribute to embed images directly in the output as data URIs when a fully self-contained file is required.
 An editor SHOULD allow configuring custom attributes and stylesheets for HTML export.
 An editor SHOULD open the generated HTML file in the system default browser upon completion.
 

--- a/docs/modules/spec/pages/language-support.adoc
+++ b/docs/modules/spec/pages/language-support.adoc
@@ -1,0 +1,56 @@
+= Language Support
+
+== File Recognition
+
+An editor MUST recognize and activate AsciiDoc support for the following file extensions:
+
+* `.adoc`
+* `.asciidoc`
+* `.ad`
+* `.asc`
+
+An editor MAY also recognize `.txt` files as AsciiDoc when they contain an AsciiDoc document header.
+
+== Syntax Highlighting
+
+An editor MUST provide syntax highlighting for the following AsciiDoc constructs:
+
+* Document header (title, author, revision, document attributes)
+* Section titles (levels 0–5)
+* Constrained and unconstrained inline formatting: bold (`*`), italic (`_`), monospace (`` ` ``), highlight (`#`), subscript (`~`), superscript (`^`)
+* Macro syntax: inline macros (e.g., `link:`, `image:`, `kbd:`, `btn:`, `menu:`) and block macros (e.g., `image::`, `include::`, `video::`, `audio::`)
+* Block delimiters: listing (` ---- `), literal (` .... `), sidebar (`****`), quote (`____`), example (`====`), passthrough (`++++`), open (`--`), comment (`////`)
+* Admonitions: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`
+* List markers: unordered (`*`, `-`), ordered (`.`), description (`::`), callout (`<n>`)
+* Attribute declarations (`:[name]:`) and references (`{name}`)
+* Cross-references: `<<target>>` and `xref:target[]`
+* Block and inline comments (`//` and `////...////`)
+* Preprocessor directives: `ifdef::`, `ifndef::`, `ifeval::`, `endif::`, `include::`
+* Table syntax (header rows, column separators, cell specifiers)
+
+An editor SHOULD additionally provide syntax highlighting for embedded languages within source code blocks (e.g., Java, Python, JavaScript, Ruby) when using `[source,lang]` blocks.
+
+An editor MAY provide distinct visual cues (e.g., folding, dimming) for comment blocks and conditional blocks.
+
+== Language Configuration
+
+An editor MUST configure the following language behaviors:
+
+* Line comment prefix: `// `
+* Block comment delimiters: `////` (open) and `////` (close)
+* Auto-closing pairs: `(`, `[`, `{`, `"`, `'`, `` ` ``
+
+An editor SHOULD also configure:
+
+* Surrounding pairs for inline formatting characters: `*`, `_`, `` ` ``, `#`, `^`, `~`
+* Word pattern that recognizes attribute references (`{name}`) as word tokens
+
+== YAML Front Matter
+
+An editor SHOULD recognize and highlight YAML front matter at the start of an AsciiDoc file (delimited by `---`) for compatibility with static site generators (Hugo, Jekyll, etc.).
+An editor implementing front matter support MUST set the `skip-front-matter` attribute during rendering so the front matter is not included in the rendered output.
+
+== Encoding
+
+An editor MUST handle AsciiDoc files encoded as UTF-8.
+An editor SHOULD detect and handle UTF-8 BOM.

--- a/docs/modules/spec/pages/navigation.adoc
+++ b/docs/modules/spec/pages/navigation.adoc
@@ -55,6 +55,17 @@ An editor SHOULD provide a "Find All References" action for:
 
 An editor MAY provide an inline "Peek Definition" panel for cross-references and includes that shows the referenced content without leaving the current document.
 
+== Hover / Quick Documentation
+
+An editor SHOULD provide hover (quick documentation) information when the cursor hovers over, or is positioned on, the following elements:
+
+* Attribute references (`{name}`) — show the resolved value and the location where the attribute is declared
+* Cross-references (`<<target>>`, `xref:target[]`) — show the title of the target section or the content of the target anchor
+* `include::` directives — show the resolved path of the included file
+* Image and media macros — show the resolved path, and where feasible a thumbnail or rendered preview of the target
+
+An editor MAY render a small HTML preview of the referenced element so that authors can inspect content without navigating away from the current document.
+
 == Document Links
 
 An editor MUST detect and make clickable the following link types within the editor:

--- a/docs/modules/spec/pages/navigation.adoc
+++ b/docs/modules/spec/pages/navigation.adoc
@@ -1,0 +1,68 @@
+= Navigation
+
+== Document Outline
+
+An editor MUST provide a document outline (structure view) showing the hierarchical tree of section titles in the current document.
+
+An editor SHOULD include the following items in the outline:
+
+* Section titles at all levels (level 0–5)
+* Explicitly defined anchors and block IDs
+
+An editor MAY also include the following items in the outline:
+
+* Tables
+* Listing and literal blocks with a title (`.Title`)
+* Images with a title
+
+An editor MUST allow navigation to any outline item by clicking or selecting it, positioning the editor cursor at the corresponding line.
+
+== Workspace Symbol Search
+
+An editor SHOULD provide a workspace-wide symbol search that allows authors to locate section titles, anchor IDs, and attribute names across all AsciiDoc files in the project.
+
+== Breadcrumbs
+
+An editor SHOULD display a breadcrumb bar showing the current cursor position within the document hierarchy (e.g., document title > section > subsection).
+
+== Go-to-Definition
+
+=== Cross-References
+
+An editor MUST provide a "Go to Definition" action for cross-references (`<<target>>` and `xref:target[]`) that navigates to the anchor or section with the matching ID, either in the current file or in another file in the workspace.
+
+=== Include Directives
+
+An editor MUST provide a "Go to Definition" action for `include::` directives that opens the referenced file at the beginning, or at the specified tag or line range if one is specified.
+
+=== Images and Media
+
+An editor SHOULD provide a "Go to Definition" action for `image::`, `video::`, and `audio::` macros that opens or reveals the referenced file.
+
+=== Attribute Declarations
+
+An editor SHOULD provide a "Go to Definition" action for attribute references (`{name}`) that navigates to the attribute declaration in the document header or in an `.asciidoctorconfig` file.
+
+== Find References
+
+An editor SHOULD provide a "Find All References" action for:
+
+* Anchor IDs — lists all cross-references pointing to the anchor
+* Document attributes — lists all locations where the attribute is referenced
+* Included files — lists all `include::` directives that reference the file
+
+== Peek Definition
+
+An editor MAY provide an inline "Peek Definition" panel for cross-references and includes that shows the referenced content without leaving the current document.
+
+== Document Links
+
+An editor MUST detect and make clickable the following link types within the editor:
+
+* External URLs (`http://`, `https://`, `ftp://`, `irc://`)
+* Cross-references: `<<target>>` and `xref:target[]`
+* Include paths: `include::path[]`
+* Image and media paths: `image::path[]`, `video::path[]`, `audio::path[]`
+
+An editor SHOULD open external URLs in the default system browser.
+An editor SHOULD open internal file references in the editor.

--- a/docs/modules/spec/pages/outline.adoc
+++ b/docs/modules/spec/pages/outline.adoc
@@ -1,40 +1,36 @@
 = AsciiDoc Editor Specification
+:description: Specification for AsciiDoc IDE and editor plugin features
+:keywords: AsciiDoc, IDE, specification, RFC
 
-== Specification Goals
+== Overview
 
-The AsciiDoc Editor Specification outlines the desired goals, functionalities, and features of an ideal text editor specifically designed for AsciiDoc authors and writers. This specification aims to define the standards and guidelines for creating a comprehensive Integrated Development Environment (IDE) tailored to the unique needs of AsciiDoc users.
+This specification defines the features and behaviors that a conformant AsciiDoc editor or IDE plugin MUST, SHOULD, or MAY implement to deliver a productive authoring experience for AsciiDoc writers.
 
-By describing how the text editor should work, how features should be implemented, and what capabilities should be available, this specification provides a clear roadmap for the development of a powerful and intuitive AsciiDoc editing tool.
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are interpreted as described in https://www.rfc-editor.org/rfc/rfc2119[RFC 2119].
 
+== Feature Areas
 
-== AsciiDoc Language Support
+* xref:language-support.adoc[Language Support] — File recognition, syntax highlighting, language configuration
+* xref:editing.adoc[Editing] — Auto-completion, snippets, text formatting shortcuts, smart pairing, image insertion
+* xref:text-folding.adoc[Text Folding] — Folding of sections, blocks, and conditional directives
+* xref:navigation.adoc[Navigation] — Document outline, go-to-definition, breadcrumbs, cross-references
+* xref:diagnostics.adoc[Diagnostics & Validation] — Error reporting, inspections, spell and grammar checking
+* xref:preview.adoc[Preview] — Live preview, scroll synchronization, security modes
+* xref:diagrams.adoc[Diagram Integration] — PlantUML, Mermaid, Kroki and other diagram renderers
+* xref:export.adoc[Export] — HTML, PDF, DOCX document generation
+* xref:refactoring.adoc[Refactoring] — Rename, extract include, inline include
+* xref:configuration.adoc[Configuration] — `.asciidoctorconfig`, custom Asciidoctor extensions
+* xref:antora.adoc[Antora Integration] — Project detection, cross-reference resolution, attribute completion
 
-// AsciiDoc Syntax highlighting
-// 
+== Conformance Levels
 
-== User Experience
+Editors implementing this specification may conform at one of the following levels:
 
-// Text folding
-// Attributes completion
-// Target completion (images, videos, include)
+Basic::
+Implements all MUST requirements across Language Support, Editing, Preview, and Export.
 
+Standard::
+Satisfies Basic, plus all SHOULD requirements across all feature areas.
 
-== Advanced Editing Capabilities
-
-// Shortcuts to apply text formatting and punctuation?
-// Tool to generate a table structure
-
-== Customization and Extensibility
-
-// Load Asciidoctor extension
-// Asciidoctor Config file .asciidoctorconfig
-// 
-
-== Collaboration and Version Control Integration
-
-
-== Preview
-
-
-== Export
-
+Advanced::
+Satisfies Standard, plus all MAY requirements, including Antora integration, diagram rendering, refactoring, and CI/CD validation.

--- a/docs/modules/spec/pages/preview.adoc
+++ b/docs/modules/spec/pages/preview.adoc
@@ -30,7 +30,8 @@ An editor SHOULD apply the Asciidoctor default stylesheet to the preview by defa
 An editor SHOULD allow authors to:
 
 * Switch to the IDE's own theme-derived stylesheet
-* Supply a custom CSS file via configuration
+* Supply a custom CSS file via configuration that replaces the default stylesheet
+* Extend the default stylesheet with additional style rules (so authors can tweak the appearance without re-supplying a complete stylesheet)
 * Configure font family, font size, and line height for the preview
 
 An editor MAY support Asciidoctor custom templates (e.g., Slim/ERB templates) that override the default HTML output.
@@ -76,6 +77,8 @@ An editor SHOULD remember the security level per workspace.
 == MathML / LaTeX Rendering
 
 An editor SHOULD support rendering of mathematical formulas using MathML or a compatible renderer (e.g., MathJax, KaTeX).
+
+An editor MAY additionally support chemical notation (e.g., the `\ce` and `\pu` macros provided by the MathJax mhchem extension) so that chemistry-oriented documents render correctly.
 
 == Link Handling
 

--- a/docs/modules/spec/pages/preview.adoc
+++ b/docs/modules/spec/pages/preview.adoc
@@ -1,0 +1,92 @@
+= Preview
+
+== Live Preview
+
+An editor MUST provide a live HTML preview of the current AsciiDoc document rendered by Asciidoctor.
+
+An editor MUST support opening the preview in a side-by-side panel alongside the editor.
+An editor SHOULD support opening the preview as a full tab.
+
+The preview MUST automatically update when the document is saved.
+An editor SHOULD support configurable auto-refresh on edit (e.g., after a debounce interval).
+An editor SHOULD provide a manual "refresh preview" action.
+
+== Rendering Engine
+
+An editor MUST use Asciidoctor (or a compatible implementation) as the rendering engine.
+The rendering engine MUST support all standard AsciiDoc constructs.
+The rendering engine SHOULD support Asciidoctor extensions loaded from the project's `.asciidoctor/lib/` directory.
+
+An editor SHOULD expose the Asciidoctor version in use and allow configuring additional attributes passed to the renderer.
+
+== Environment Attribute
+
+An editor MUST set an environment attribute in the preview to allow authors to use conditional content for IDE-specific output.
+Recommended attribute names: `env-idea` (IntelliJ), `env-vscode` (VS Code), or the generic `env` attribute set to the IDE name.
+
+== Preview Styling
+
+An editor SHOULD apply the Asciidoctor default stylesheet to the preview by default.
+An editor SHOULD allow authors to:
+
+* Switch to the IDE's own theme-derived stylesheet
+* Supply a custom CSS file via configuration
+* Configure font family, font size, and line height for the preview
+
+An editor MAY support Asciidoctor custom templates (e.g., Slim/ERB templates) that override the default HTML output.
+
+== Scroll Synchronization
+
+An editor SHOULD synchronize the preview scroll position with the editor cursor position, so that the preview automatically scrolls to show the content corresponding to the current cursor location.
+
+An editor SHOULD also synchronize in the reverse direction: scrolling the preview should scroll the editor to the corresponding position.
+
+An editor MUST allow users to disable scroll synchronization independently for each direction.
+
+== Preview-to-Source Navigation
+
+An editor SHOULD allow authors to navigate from a location in the preview to the corresponding source line in the editor.
+Recommended interactions: double-click or `Ctrl+Click` on preview content.
+
+An editor SHOULD highlight the editor line or block corresponding to the currently focused preview element.
+
+== Zoom
+
+An editor MAY support zooming the preview in and out (e.g., via `Ctrl+scroll wheel`).
+
+== Security
+
+An editor MUST enforce a content security policy for the preview to protect against script injection.
+
+An editor MUST provide multiple security levels, including at minimum:
+
+Strict::
+No scripts, no remote content, no `file://` access. Safest default.
+
+Allow Insecure Content::
+Permits mixed `http://` and `https://` content.
+
+Allow Scripts and Unsafe Content::
+Permits JavaScript execution and arbitrary remote content loading.
+
+An editor SHOULD default to the strictest security mode.
+An editor MUST warn users when they downgrade to a less restrictive security mode.
+An editor SHOULD remember the security level per workspace.
+
+== MathML / LaTeX Rendering
+
+An editor SHOULD support rendering of mathematical formulas using MathML or a compatible renderer (e.g., MathJax, KaTeX).
+
+== Link Handling
+
+An editor MUST open external URLs (`http://`, `https://`) in the system default browser when clicked in the preview.
+
+An editor SHOULD open internal AsciiDoc file links either in the preview or in the editor, based on user configuration.
+
+== Locked Preview
+
+An editor MAY support a "locked" preview mode that pins the preview to a specific document and prevents it from switching when the editor focus changes to a different file.
+
+== Preview State Preservation
+
+An editor MAY keep the preview rendering in memory when the preview panel is hidden, so that it reloads instantly without re-rendering when shown again.

--- a/docs/modules/spec/pages/refactoring.adoc
+++ b/docs/modules/spec/pages/refactoring.adoc
@@ -1,0 +1,54 @@
+= Refactoring
+
+== Rename
+
+An editor SHOULD provide a rename refactoring for the following AsciiDoc elements:
+
+* **Anchor IDs**: renaming an anchor (`[[id]]` or `[id]`) updates all `xref:id[]` and `<<id>>` cross-references pointing to it across all files in the workspace.
+* **Document attributes**: renaming an attribute declaration (`:[name]:`) updates all `{name}` references throughout the document and, where applicable, across other files.
+* **File names**: renaming an AsciiDoc file updates all `include::` directives and `xref:` references that target it across the workspace.
+
+Rename refactoring MUST be preview-able before being applied (showing which files and lines will change).
+Rename refactoring MUST be undoable as a single atomic action.
+
+== Extract Include
+
+An editor SHOULD provide an "Extract Include" refactoring that:
+
+1. Takes a selected region of AsciiDoc content
+2. Creates a new file with that content
+3. Replaces the selected region with an `include::` directive pointing to the new file
+
+An editor implementing Extract Include SHOULD:
+
+* Prompt for the target file name and location
+* Compute the correct relative path for the `include::` directive
+* Preserve block delimiters and attributes that belong to the extracted content
+
+== Inline Include
+
+An editor SHOULD provide an "Inline Include" refactoring that replaces an `include::` directive with the actual content of the referenced file.
+
+An editor implementing Inline Include SHOULD:
+
+* Preserve the content verbatim
+* Remove only the `include::` line
+
+== Markdown to AsciiDoc Conversion
+
+An editor MAY provide a "Convert Markdown to AsciiDoc" action available on `.md` files that produces an equivalent `.adoc` file using Pandoc or a compatible converter.
+This conversion MUST be undoable.
+
+An editor MAY suggest this conversion via an inspection when a Markdown file is opened.
+
+== Single-Line to Block Admonition
+
+An editor MAY provide an intention action to convert a single-line admonition (e.g., `NOTE: text`) to its block equivalent:
+
+[listing]
+----
+[NOTE]
+====
+text
+====
+----

--- a/docs/modules/spec/pages/text-folding.adoc
+++ b/docs/modules/spec/pages/text-folding.adoc
@@ -1,0 +1,53 @@
+= Text Folding
+
+== Overview
+
+Text folding (also called code folding) allows authors to collapse and expand regions of an AsciiDoc document to reduce visual noise and focus on the content currently being edited.
+
+== Section Folding
+
+An editor MUST support folding of document sections starting from the section title line down to (but not including) the next section at the same or higher level.
+
+An editor MUST support folding at all section levels (level 1 through level 5, i.e., `==` through `======`).
+
+An editor SHOULD display a fold indicator (e.g., a chevron or triangle) in the gutter next to each foldable section title.
+
+== Block Folding
+
+An editor SHOULD support folding of delimited blocks, including:
+
+* Listing blocks (` ---- `)
+* Literal blocks (` .... `)
+* Sidebar blocks (`****`)
+* Quote blocks (`____`)
+* Example blocks (`====`)
+* Passthrough blocks (`++++`)
+* Open blocks (`--`)
+* Comment blocks (`////`)
+* Table blocks (`|===`)
+
+The fold region MUST span from the opening delimiter line to the closing delimiter line (inclusive).
+
+== Conditional Block Folding
+
+An editor SHOULD support folding of conditional preprocessor blocks:
+
+* `ifdef::attribute[]` ... `endif::attribute[]`
+* `ifndef::attribute[]` ... `endif::attribute[]`
+* `ifeval::[expression]` ... `endif::[]`
+
+The fold region MUST span from the `ifdef::`/`ifndef::`/`ifeval::` directive to the matching `endif::` directive.
+
+== Comment Block Folding
+
+An editor SHOULD support folding of comment blocks delimited by `////`.
+
+An editor MAY collapse comment blocks by default when a document is first opened.
+
+== Attribute Folding
+
+An editor MAY visually replace attribute references (e.g., `{plus}`, `{sp}`, `{nbsp}`) with their resolved values or Unicode equivalents in the editor view, using a "folded" inline representation.
+
+== Fold State Persistence
+
+An editor MAY persist the fold state of a document across editing sessions so that previously collapsed sections remain collapsed when the document is reopened.


### PR DESCRIPTION
Add a comprehensive RFC 2119-style specification (MUST/SHOULD/MAY) covering 11 feature areas: language support, editing, text folding, navigation, diagnostics, preview, diagram integration, export, refactoring, configuration, and Antora integration. Includes a spec module nav and antora.yml update.