### PR TITLE
feat: asciidoctor extension registration api

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,55 +163,6 @@ Here's an example of how to use the [asciidoctor-emoji](https://github.com/mogzt
 
 ![Asciidoctor.js Emoji extension enabled!](images/asciidoctor-vscode-emoji-ext.png)
 
-### Register Asciidoctor.js extensions from another VS Code extension
-
-VS Code extensions can register Asciidoctor.js extensions with this extension
-without writing JavaScript files into the user's workspace. This is intended for
-extension authors who want to provide a packaged Asciidoctor.js extension that is
-automatically used by the normal AsciiDoc preview and export commands.
-
-Activate `asciidoctor.asciidoctor-vscode`, then call
-`registerAsciidoctorExtension()` on the returned API:
-
-```typescript
-import * as vscode from 'vscode'
-
-interface AsciidoctorExtensionRegistration {
-  register(registry: unknown, documentUri?: vscode.Uri): void | Promise<void>
-}
-
-interface AsciidoctorVscodeApi {
-  registerAsciidoctorExtension(
-    extension: AsciidoctorExtensionRegistration,
-  ): vscode.Disposable
-}
-
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const asciidoctorVscode =
-    vscode.extensions.getExtension<AsciidoctorVscodeApi>(
-      'asciidoctor.asciidoctor-vscode',
-    )
-
-  if (asciidoctorVscode === undefined) {
-    return
-  }
-
-  const api = await asciidoctorVscode.activate()
-  context.subscriptions.push(
-    api.registerAsciidoctorExtension({
-      register(registry, documentUri) {
-        // Register your Asciidoctor.js extension here.
-        // Use documentUri to read resource-scoped VS Code settings if needed.
-      },
-    }),
-  )
-}
-```
-
-The callback is invoked each time this extension creates a new Asciidoctor
-extension registry for preview, export, or document analysis. The returned
-`Disposable` unregisters the callback when disposed.
-
 ### Asciidoctor Config File
 
 To provide a common set of variables when rendering the preview, the extension reads an `.asciidoctorconfig` or `.asciidoctorconfig.adoc` configuration file. Use this to optimize the preview when the project contains a document that is split out to multiple include-files.
@@ -269,6 +220,55 @@ This extension contributes the following settings:
 |:----------------------------------------|:--------------------------------------------------------------------------------|:--------------|
 | `asciidoc.debug.trace`                  | Enable debug logging for this extension. Possible values: `"off"`, `"verbose"`. | `"off"`       |
 | `asciidoc.debug.enableErrorDiagnostics` | Provide error diagnostics.                                                      | `true`        |
+
+## Register Asciidoctor.js extensions from another VS Code extension
+
+VS Code extensions can register Asciidoctor.js extensions with this extension
+without writing JavaScript files into the user's workspace. This is intended for
+extension authors who want to provide a packaged Asciidoctor.js extension that is
+automatically used by the normal AsciiDoc preview and export commands.
+
+Activate `asciidoctor.asciidoctor-vscode`, then call
+`registerAsciidoctorExtension()` on the returned API:
+
+```typescript
+import * as vscode from 'vscode'
+
+interface AsciidoctorExtensionRegistration {
+  register(registry: unknown, documentUri?: vscode.Uri): void | Promise<void>
+}
+
+interface AsciidoctorVscodeApi {
+  registerAsciidoctorExtension(
+    extension: AsciidoctorExtensionRegistration,
+  ): vscode.Disposable
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const asciidoctorVscode =
+    vscode.extensions.getExtension<AsciidoctorVscodeApi>(
+      'asciidoctor.asciidoctor-vscode',
+    )
+
+  if (asciidoctorVscode === undefined) {
+    return
+  }
+
+  const api = await asciidoctorVscode.activate()
+  context.subscriptions.push(
+    api.registerAsciidoctorExtension({
+      register(registry, documentUri) {
+        // Register your Asciidoctor.js extension here.
+        // Use documentUri to read resource-scoped VS Code settings if needed.
+      },
+    }),
+  )
+}
+```
+
+The callback is invoked each time this extension creates a new Asciidoctor
+extension registry for preview, export, or document analysis. The returned
+`Disposable` unregisters the callback when disposed.
 
 ## Build and Install from Source
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,55 @@ Here's an example of how to use the [asciidoctor-emoji](https://github.com/mogzt
 
 ![Asciidoctor.js Emoji extension enabled!](images/asciidoctor-vscode-emoji-ext.png)
 
+### Register Asciidoctor.js extensions from another VS Code extension
+
+VS Code extensions can register Asciidoctor.js extensions with this extension
+without writing JavaScript files into the user's workspace. This is intended for
+extension authors who want to provide a packaged Asciidoctor.js extension that is
+automatically used by the normal AsciiDoc preview and export commands.
+
+Activate `asciidoctor.asciidoctor-vscode`, then call
+`registerAsciidoctorExtension()` on the returned API:
+
+```typescript
+import * as vscode from 'vscode'
+
+interface AsciidoctorExtensionRegistration {
+  register(registry: unknown, documentUri?: vscode.Uri): void | Promise<void>
+}
+
+interface AsciidoctorVscodeApi {
+  registerAsciidoctorExtension(
+    extension: AsciidoctorExtensionRegistration,
+  ): vscode.Disposable
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const asciidoctorVscode =
+    vscode.extensions.getExtension<AsciidoctorVscodeApi>(
+      'asciidoctor.asciidoctor-vscode',
+    )
+
+  if (asciidoctorVscode === undefined) {
+    return
+  }
+
+  const api = await asciidoctorVscode.activate()
+  context.subscriptions.push(
+    api.registerAsciidoctorExtension({
+      register(registry, documentUri) {
+        // Register your Asciidoctor.js extension here.
+        // Use documentUri to read resource-scoped VS Code settings if needed.
+      },
+    }),
+  )
+}
+```
+
+The callback is invoked each time this extension creates a new Asciidoctor
+extension registry for preview, export, or document analysis. The returned
+`Disposable` unregisters the callback when disposed.
+
 ### Asciidoctor Config File
 
 To provide a common set of variables when rendering the preview, the extension reads an `.asciidoctorconfig` or `.asciidoctorconfig.adoc` configuration file. Use this to optimize the preview when the project contains a document that is split out to multiple include-files.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,10 @@ import {
 } from './features/asciidoctor/asciidocLoader.js'
 import { AsciidoctorConfig } from './features/asciidoctor/asciidoctorConfig.js'
 import { AsciidoctorDiagnostic } from './features/asciidoctor/asciidoctorDiagnostic.js'
-import { AsciidoctorExtensions } from './features/asciidoctor/asciidoctorExtensions.js'
+import {
+  AsciidoctorExtensionRegistrationApi,
+  AsciidoctorExtensions,
+} from './features/asciidoctor/asciidoctorExtensions.js'
 import { AsciidoctorIncludeItems } from './features/asciidoctor/asciidoctorIncludeItems.js'
 import { AsciidocCompletionProviders } from './features/completion/completionProviders.js'
 import LinkProvider from './features/documentLinkProvider.js'
@@ -30,7 +33,9 @@ import {
 } from './features/security.js'
 import AsciidocWorkspaceSymbolProvider from './features/workspaceSymbolProvider.js'
 
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<AsciidoctorExtensionRegistrationApi> {
   // Set context as a global as some tests depend on it
   ;(globalThis as any).testExtensionContext = context
   const contributionProvider = getAsciidocExtensionContributions(context)
@@ -198,4 +203,9 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     }),
   )
+
+  return {
+    registerAsciidoctorExtension:
+      AsciidoctorExtensions.registerAsciidoctorExtension,
+  }
 }

--- a/src/features/asciidoctor/asciidocEngine.ts
+++ b/src/features/asciidoctor/asciidocEngine.ts
@@ -50,8 +50,8 @@ export class AsciidocEngine {
     const memoryLogger = asciidoctorProcessor.activateMemoryLogger()
 
     const registry = Extensions.create()
-    await this.asciidoctorExtensionsProvider.activate(registry)
     const textDocumentUri = textDocument.uri
+    await this.asciidoctorExtensionsProvider.activate(registry, textDocumentUri)
     await this.asciidoctorConfigProvider.activate(registry, textDocumentUri)
     asciidoctorProcessor.restoreBuiltInSyntaxHighlighter()
 
@@ -154,8 +154,8 @@ export class AsciidocEngine {
     ConverterFactory.register(asciidoctorWebViewConverter, 'webview-html5')
 
     const registry = Extensions.create()
-    await this.asciidoctorExtensionsProvider.activate(registry)
     const textDocumentUri = textDocument.uri
+    await this.asciidoctorExtensionsProvider.activate(registry, textDocumentUri)
     await this.asciidoctorConfigProvider.activate(registry, textDocumentUri)
     if (antoraDocumentContext !== undefined) {
       const antoraConfig = await getAntoraConfig(textDocumentUri)

--- a/src/features/asciidoctor/asciidocLoader.ts
+++ b/src/features/asciidoctor/asciidocLoader.ts
@@ -62,8 +62,8 @@ export class AsciidocLoader {
     LoggerManager.setLogger(memoryLogger)
 
     const registry = Extensions.create()
-    await this.asciidoctorExtensionsProvider.activate(registry)
     const textDocumentUri = textDocument.uri
+    await this.asciidoctorExtensionsProvider.activate(registry, textDocumentUri)
     await this.asciidoctorConfigProvider.activate(registry, textDocumentUri)
     const antoraDocumentContext = await getAntoraDocumentContext(
       textDocument.uri,

--- a/src/features/asciidoctor/asciidoctorExtensions.ts
+++ b/src/features/asciidoctor/asciidoctorExtensions.ts
@@ -5,10 +5,22 @@ import { mermaidJSProcessor } from '../preview/mermaid.js'
 import { AsciidoctorExtensionsSecurityPolicyArbiter } from '../security.js'
 
 export interface AsciidoctorExtensionsProvider {
-  activate(registry: Registry): Promise<void>
+  activate(registry: Registry, documentUri?: vscode.Uri): Promise<void>
+}
+
+export interface AsciidoctorExtensionRegistration {
+  register(registry: Registry, documentUri?: vscode.Uri): void | Promise<void>
+}
+
+export interface AsciidoctorExtensionRegistrationApi {
+  registerAsciidoctorExtension(
+    extension: AsciidoctorExtensionRegistration,
+  ): vscode.Disposable
 }
 
 export class AsciidoctorExtensions {
+  private static readonly registeredExtensions =
+    new Set<AsciidoctorExtensionRegistration>()
   private asciidoctorExtensionsSecurityPolicy: AsciidoctorExtensionsSecurityPolicyArbiter
 
   constructor(
@@ -18,7 +30,18 @@ export class AsciidoctorExtensions {
       asciidoctorExtensionsSecurityPolicy
   }
 
-  public async activate(registry: Registry) {
+  public static registerAsciidoctorExtension(
+    extension: AsciidoctorExtensionRegistration,
+  ): vscode.Disposable {
+    AsciidoctorExtensions.registeredExtensions.add(extension)
+    return {
+      dispose(): void {
+        AsciidoctorExtensions.registeredExtensions.delete(extension)
+      },
+    }
+  }
+
+  public async activate(registry: Registry, documentUri?: vscode.Uri) {
     const enableKroki = vscode.workspace
       .getConfiguration('asciidoc.extensions', null)
       .get('enableKroki')
@@ -29,7 +52,21 @@ export class AsciidoctorExtensions {
       )
     }
     registry.block('mermaid', mermaidJSProcessor())
+    await this.registerExtensionsFromApi(registry, documentUri)
     await this.registerExtensionsInWorkspace(registry)
+  }
+
+  private async registerExtensionsFromApi(
+    registry: Registry,
+    documentUri?: vscode.Uri,
+  ): Promise<void> {
+    for (const extension of AsciidoctorExtensions.registeredExtensions) {
+      try {
+        await extension.register(registry, documentUri)
+      } catch (e) {
+        vscode.window.showErrorMessage(e.toString())
+      }
+    }
   }
 
   private async confirmAsciidoctorExtensionsTrusted(): Promise<boolean> {


### PR DESCRIPTION
resolves #1033

## Summary

Adds a public registration API so other VS Code extensions can attach Asciidoctor.js extensions to the normal `asciidoctor-vscode` preview, export, and document-analysis flows.

This keeps `asciidoctor-vscode` generic: it does not know about any specific companion extension. Companion extensions activate `asciidoctor.asciidoctor-vscode`, obtain the returned API, and register their own Asciidoctor.js extension callback.

## Security Motivation

This is an improvement for the security concerns discussed in https://github.com/asciidoctor/asciidoctor-vscode/pull/569.

PR #569 added workspace-based Asciidoctor.js extension loading from `.asciidoctor/lib`, but that model necessarily executes JavaScript that lives inside the opened workspace. Review discussion raised the risk that opening or previewing a project could execute project-provided code, which required explicit settings and trust prompts.

The API added here gives extension authors another integration path: package the Asciidoctor.js extension inside a VS Code extension and register it through `asciidoctor-vscode`. This avoids asking users to copy executable JavaScript into every workspace and lets installation/update/trust decisions happen through VS Code's extension model instead of per-workspace files.

## Details

- Exposes `registerAsciidoctorExtension()` from this extension's `activate()` return value.
- Stores registered callbacks centrally so all `AsciidoctorExtensions` instances use the same registrations.
- Invokes registered callbacks whenever a new Asciidoctor extension registry is created.
- Passes the current document URI to callbacks so companion extensions can read resource-scoped VS Code settings.
- Preserves the existing workspace `.asciidoctor/lib/**/*.js` registration behavior and trust flow.
- Documents the API in `README.md` for developers building VS Code extensions on top of `asciidoctor-vscode`.

## Usage Example

A sample consumer of this API is https://github.com/YoshihideShirai/asciidoctor-numbered-captions-vscode.

That extension bundles `github:YoshihideShirai/asciidoctor-numbered-captions`, registers it through this API, and delegates preview/export rendering back to `asciidoctor-vscode`.

## Related

- Companion implementation: `YoshihideShirai/asciidoctor-numbered-captions-vscode#1`
- Original workspace-extension discussion: https://github.com/asciidoctor/asciidoctor-vscode/pull/569

## Validation

- `npm run build-ext`
- `npm run package`