### PR TITLE
ci: source Node version from package.json and bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version-file: 'package.json'
     - run: npm ci --foreground-scripts
     - run: npm run lint
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ jobs:
     environment: releases
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: 'package.json'
       - name: Install dependencies
         run: npm ci
       - name: Setup release environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Upgrade Mermaid from 10.9.0 to 11.15.0
 * Upgrade TypeScript from 4.9.5 to 5.x (#1003)
 * Reduce npm audit vulnerabilities (#1002)
+* Source the CI Node.js version from `package.json` (`volta.node`) and bump `actions/checkout` to v7 and `actions/setup-node` to v6
 
 ## 3.4.5  (2025-09-16)
 


### PR DESCRIPTION
Use node-version-file pointing to package.json so the Node version is managed in a single place (volta.node). Also bump actions/checkout to v7 and actions/setup-node to v6.
