### PR TITLE
chore(deps): pin @types/node to v24 and delay TypeScript majors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@highlightjs/cdn-assets": "~11.11.0",
         "@playwright/test": "^1.47.2",
         "@types/lodash.throttle": "~4.1",
-        "@types/node": "^22.19.17",
+        "@types/node": "^24.0.0",
         "@types/vscode": "~1.88.0",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "3.9.1",
@@ -1906,13 +1906,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -7315,9 +7315,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -642,7 +642,7 @@
     "@highlightjs/cdn-assets": "~11.11.0",
     "@playwright/test": "^1.47.2",
     "@types/lodash.throttle": "~4.1",
-    "@types/node": "^22.19.17",
+    "@types/node": "^24.0.0",
     "@types/vscode": "~1.88.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "3.9.1",

--- a/renovate.json5
+++ b/renovate.json5
@@ -60,6 +60,21 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["typescript", "@types/node", "@types/lodash.throttle"],
       "groupName": "TypeScript"
+    },
+    {
+      // Keep @types/node aligned with the Node.js major we target (24);
+      // never bump to 25+.
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "<25"
+    },
+    {
+      // Hold off on TypeScript major upgrades (e.g. 6.x) for 3 weeks
+      // so the ecosystem can stabilise first.
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "21 days"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Keep @types/node aligned with the Node.js major we target by capping Renovate at <25, and hold TypeScript major upgrades (e.g. 6.x) for 3 weeks via minimumReleaseAge. Bump @types/node to ^24 accordingly.
