### PR TITLE
perf(antora): cache content catalog and skip reading binary resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Fix Windows path generation by using `fsPath` (#998) - thanks @anoymouserver
 * Fix TextMate grammar: support dots as delimiter in listing paragraph (#1004)
 
+### Improvements
+
+* Improve Antora performance on large projects: cache the Antora configuration and content catalog instead of rebuilding them on every preview render, invalidating through file system watchers, and stop loading the bytes of binary resources (images, attachments) into the content catalog (#434)
+
 ### Infrastructure
 
 * Migrate from webpack to esbuild

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { CommandManager } from './core/commandManager.js'
 import { asciidocDocumentSelector } from './core/document.js'
 import { Logger } from './core/logger.js'
 import { AntoraSupportManager } from './features/antora/antoraContext.js'
+import { registerAntoraCacheInvalidation } from './features/antora/antoraDocument.js'
 import { AsciidocEngine } from './features/asciidoctor/asciidocEngine.js'
 import {
   AsciidocIncludeItemsLoader,
@@ -86,6 +87,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     AntoraSupportManager.getInstance(context.workspaceState),
   )
+  context.subscriptions.push(registerAntoraCacheInvalidation())
   context.subscriptions.push(
     vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider),
   )

--- a/src/features/antora/antoraDocument.ts
+++ b/src/features/antora/antoraDocument.ts
@@ -3,7 +3,7 @@ import { posix as posixpath } from 'node:path'
 import * as contentClassifier from '@antora/content-classifier'
 import yaml from 'js-yaml'
 import * as vscode from 'vscode'
-import { CancellationTokenSource, FileType, Memento, Uri } from 'vscode'
+import { FileType, Memento, Uri } from 'vscode'
 import { dir, exists } from '../../core/file.js'
 import { findFiles } from '../../core/findFiles.js'
 import { getWorkspaceFolder } from '../../core/workspace.js'
@@ -18,15 +18,75 @@ const classifyContent = contentClassifier.default || contentClassifier
 
 const MAX_DEPTH_SEARCH_ANTORA_CONFIG = 100
 
+// Antora content families whose files are AsciiDoc/text and may be pulled into a
+// page (e.g. through an include). Only those need their contents loaded into the
+// content catalog; binary families (images, attachments, assets) are referenced
+// by resource id only, so reading their bytes into memory is pure overhead.
+const TEXT_FAMILY_DIRS = new Set(['pages', 'partials', 'examples'])
+const EMPTY_CONTENTS = Buffer.alloc(0)
+
+function isTextResource(relativePath: string): boolean {
+  // relative path looks like `modules/<module>/<family>/...`
+  const family = relativePath.split('/')[2]
+  return family !== undefined && TEXT_FAMILY_DIRS.has(family)
+}
+
+// Building the Antora content catalog means globbing the whole workspace and
+// reading every content file, then running the content classifier. This is far
+// too expensive to redo on every preview render (i.e. on virtually every
+// keystroke), so we memoize the expensive pieces and reuse them until a relevant
+// file changes on disk. Each cache holds the in-flight promise as well, so
+// concurrent renders share a single build instead of racing.
+let antoraConfigUrisPromise: Promise<Uri[]> | undefined
+let antoraConfigsPromise: Promise<AntoraConfig[]> | undefined
+let contentCatalogPromise: Promise<any> | undefined
+
+/**
+ * Drop every cached Antora artifact. Called by the file system watchers when a
+ * configuration or content file changes, and by tests between scenarios.
+ */
+export function clearAntoraCache(): void {
+  antoraConfigUrisPromise = undefined
+  antoraConfigsPromise = undefined
+  contentCatalogPromise = undefined
+}
+
+/**
+ * Register file system watchers that invalidate the Antora caches whenever an
+ * `antora.yml` or a file below a `modules` directory is created, changed or
+ * removed. Returns a disposable that tears the watchers down.
+ */
+export function registerAntoraCacheInvalidation(): vscode.Disposable {
+  const invalidate = () => clearAntoraCache()
+  const watchers = [
+    vscode.workspace.createFileSystemWatcher('**/antora.yml'),
+    vscode.workspace.createFileSystemWatcher('**/modules/**'),
+  ]
+  for (const watcher of watchers) {
+    watcher.onDidCreate(invalidate)
+    watcher.onDidChange(invalidate)
+    watcher.onDidDelete(invalidate)
+  }
+  return vscode.Disposable.from(...watchers)
+}
+
+function getAntoraConfigUris(): Promise<Uri[]> {
+  if (antoraConfigUrisPromise === undefined) {
+    antoraConfigUrisPromise = Promise.resolve(findFiles('**/antora.yml')).catch(
+      (err) => {
+        antoraConfigUrisPromise = undefined
+        throw err
+      },
+    )
+  }
+  return antoraConfigUrisPromise
+}
+
 export async function findAntoraConfigFile(
   textDocumentUri: Uri,
 ): Promise<Uri | undefined> {
   const asciidocFilePath = posixpath.normalize(textDocumentUri.path)
-  const cancellationToken = new CancellationTokenSource()
-  cancellationToken.token.onCancellationRequested((e) => {
-    console.log('Cancellation requested, cause: ' + e)
-  })
-  const antoraConfigUris = await findFiles('**/antora.yml')
+  const antoraConfigUris = await getAntoraConfigUris()
   // check for Antora configuration
   for (const antoraConfigUri of antoraConfigUris) {
     const antoraConfigParentDirPath = antoraConfigUri.path.slice(
@@ -92,12 +152,18 @@ export async function antoraConfigFileExists(
   return antoraConfig !== undefined
 }
 
-async function getAntoraConfigs(): Promise<AntoraConfig[]> {
-  const cancellationToken = new CancellationTokenSource()
-  cancellationToken.token.onCancellationRequested((e) => {
-    console.log('Cancellation requested, cause: ' + e)
-  })
-  const antoraConfigUris = await findFiles('**/antora.yml')
+function getAntoraConfigs(): Promise<AntoraConfig[]> {
+  if (antoraConfigsPromise === undefined) {
+    antoraConfigsPromise = buildAntoraConfigs().catch((err) => {
+      antoraConfigsPromise = undefined
+      throw err
+    })
+  }
+  return antoraConfigsPromise
+}
+
+async function buildAntoraConfigs(): Promise<AntoraConfig[]> {
+  const antoraConfigUris = await getAntoraConfigUris()
   // check for Antora configuration
   const antoraConfigs = await Promise.all(
     antoraConfigUris.map(async (antoraConfigUri) => {
@@ -159,6 +225,90 @@ export async function getAttributes(
   return antoraConfig.config.asciidoc?.attributes || {}
 }
 
+function getContentCatalog(): Promise<any> {
+  if (contentCatalogPromise === undefined) {
+    contentCatalogPromise = buildContentCatalog().catch((err) => {
+      contentCatalogPromise = undefined
+      throw err
+    })
+  }
+  return contentCatalogPromise
+}
+
+async function buildContentCatalog(): Promise<any> {
+  const antoraConfigs = await getAntoraConfigs()
+  const contentAggregate: { name: string; version: string; files: any[] }[] =
+    await Promise.all(
+      antoraConfigs
+        .filter(
+          (antoraConfig) =>
+            antoraConfig.config !== undefined &&
+            'name' in antoraConfig.config &&
+            'version' in antoraConfig.config,
+        )
+        .map(async (antoraConfig) => {
+          const workspaceFolder = getWorkspaceFolder(antoraConfig.uri)
+          const workspaceRelative = posixpath.relative(
+            workspaceFolder.uri.path,
+            antoraConfig.contentSourceRootPath,
+          )
+          const globPattern =
+            'modules/*/{attachments,examples,images,pages,partials,assets}/**'
+          const contentSourceRootPath = antoraConfig.contentSourceRootPath
+          const files = await Promise.all(
+            (
+              await findFiles(
+                `${workspaceRelative ? `${workspaceRelative}/` : ''}${globPattern}`,
+              )
+            ).map(async (file) => {
+              const relativePath = posixpath.relative(
+                contentSourceRootPath,
+                file.path,
+              )
+              // Only AsciiDoc/text resources can be pulled into a page; loading
+              // the bytes of images & attachments would waste time and memory.
+              const contents = isTextResource(relativePath)
+                ? Buffer.from(await vscode.workspace.fs.readFile(file))
+                : EMPTY_CONTENTS
+              return {
+                base: contentSourceRootPath,
+                path: relativePath,
+                contents,
+                extname: posixpath.extname(file.path),
+                stem: posixpath.basename(
+                  file.path,
+                  posixpath.extname(file.path),
+                ),
+                src: {
+                  abspath: file.path,
+                  basename: posixpath.basename(file.path),
+                  editUrl: '',
+                  extname: posixpath.extname(file.path),
+                  path: file.path,
+                  stem: posixpath.basename(
+                    file.path,
+                    posixpath.extname(file.path),
+                  ),
+                },
+              }
+            }),
+          )
+          return {
+            name: antoraConfig.config.name,
+            version: antoraConfig.config.version,
+            ...antoraConfig.config,
+            files,
+          }
+        }),
+    )
+  return classifyContent(
+    {
+      site: {},
+    },
+    contentAggregate,
+  )
+}
+
 export async function getAntoraDocumentContext(
   textDocumentUri: Uri,
   workspaceState: Memento,
@@ -168,70 +318,7 @@ export async function getAntoraDocumentContext(
     return undefined
   }
   try {
-    const antoraConfigs = await getAntoraConfigs()
-    const contentAggregate: { name: string; version: string; files: any[] }[] =
-      await Promise.all(
-        antoraConfigs
-          .filter(
-            (antoraConfig) =>
-              antoraConfig.config !== undefined &&
-              'name' in antoraConfig.config &&
-              'version' in antoraConfig.config,
-          )
-          .map(async (antoraConfig) => {
-            const workspaceFolder = getWorkspaceFolder(antoraConfig.uri)
-            const workspaceRelative = posixpath.relative(
-              workspaceFolder.uri.path,
-              antoraConfig.contentSourceRootPath,
-            )
-            const globPattern =
-              'modules/*/{attachments,examples,images,pages,partials,assets}/**'
-            const files = await Promise.all(
-              (
-                await findFiles(
-                  `${workspaceRelative ? `${workspaceRelative}/` : ''}${globPattern}`,
-                )
-              ).map(async (file) => {
-                const contentSourceRootPath = antoraConfig.contentSourceRootPath
-                return {
-                  base: contentSourceRootPath,
-                  path: posixpath.relative(contentSourceRootPath, file.path),
-                  contents: Buffer.from(
-                    await vscode.workspace.fs.readFile(file),
-                  ),
-                  extname: posixpath.extname(file.path),
-                  stem: posixpath.basename(
-                    file.path,
-                    posixpath.extname(file.path),
-                  ),
-                  src: {
-                    abspath: file.path,
-                    basename: posixpath.basename(file.path),
-                    editUrl: '',
-                    extname: posixpath.extname(file.path),
-                    path: file.path,
-                    stem: posixpath.basename(
-                      file.path,
-                      posixpath.extname(file.path),
-                    ),
-                  },
-                }
-              }),
-            )
-            return {
-              name: antoraConfig.config.name,
-              version: antoraConfig.config.version,
-              ...antoraConfig.config,
-              files,
-            }
-          }),
-      )
-    const contentCatalog = await classifyContent(
-      {
-        site: {},
-      },
-      contentAggregate,
-    )
+    const contentCatalog = await getContentCatalog()
     const antoraContext = new AntoraContext(contentCatalog)
     const antoraResourceContext =
       await antoraContext.getResource(textDocumentUri)

--- a/src/features/antora/antoraDocumentBrowserShim.ts
+++ b/src/features/antora/antoraDocumentBrowserShim.ts
@@ -1,5 +1,15 @@
+import * as vscode from 'vscode'
 import { Memento, Uri } from 'vscode'
 import { AntoraConfig, AntoraDocumentContext } from './antoraContext.js'
+
+export function clearAntoraCache(): void {
+  // no-op in the browser, Antora support is not available
+}
+
+export function registerAntoraCacheInvalidation(): vscode.Disposable {
+  // no-op in the browser, Antora support is not available
+  return new vscode.Disposable(() => undefined)
+}
 
 export async function findAntoraConfigFile(_: Uri): Promise<Uri | undefined> {
   return undefined

--- a/src/test/antoraSupport.test.ts
+++ b/src/test/antoraSupport.test.ts
@@ -4,6 +4,7 @@ import { after, before, describe, test } from 'node:test'
 import * as vscode from 'vscode'
 import { getDefaultWorkspaceFolderUri } from '../core/workspace.js'
 import {
+  clearAntoraCache,
   findAntoraConfigFile,
   getAntoraDocumentContext,
 } from '../features/antora/antoraDocument.js'
@@ -317,6 +318,185 @@ describe('Antora support with single documentation component', () => {
       assert.strictEqual(images[0].src.component, 'ROOT')
       assert.strictEqual(images[0].src.family, 'image')
       assert.strictEqual(images[0].src.version, null)
+    } finally {
+      await removeFiles(createdFiles)
+      await resetAntoraSupport()
+    }
+  })
+})
+
+describe('Antora content catalog construction', () => {
+  test('Should load contents of text resources but not of binary resources', async () => {
+    const createdFiles = []
+    try {
+      createdFiles.push(await createDirectory('modules'))
+      await createDirectories('modules', 'ROOT', 'pages')
+      const asciidocFile = await createFile(
+        'include::partial$intro.adoc[]\n\nimage:mountain.jpeg[]',
+        'modules',
+        'ROOT',
+        'pages',
+        'landscape.adoc',
+      )
+      createdFiles.push(asciidocFile)
+      createdFiles.push(
+        await createFile(
+          'Reusable introduction',
+          'modules',
+          'ROOT',
+          'partials',
+          'intro.adoc',
+        ),
+      )
+      // Give the image a non-empty content on purpose: the catalog must NOT read
+      // those bytes, so its contents in the catalog must stay empty.
+      createdFiles.push(
+        await createFile(
+          'pretend-this-is-a-large-binary-image',
+          'modules',
+          'ROOT',
+          'images',
+          'mountain.jpeg',
+        ),
+      )
+      createdFiles.push(
+        await createFile(`name: ROOT\nversion: ~\n`, 'antora.yml'),
+      )
+      await enableAntoraSupport()
+      const result = await getAntoraDocumentContext(
+        asciidocFile,
+        extensionContext.workspaceState,
+      )
+      const contentCatalog = result.getContentCatalog()
+
+      const partial = contentCatalog.findBy({ family: 'partial' })[0]
+      assert.strictEqual(
+        partial !== undefined,
+        true,
+        'Partial must be present in the content catalog',
+      )
+      assert.strictEqual(
+        partial.contents.toString(),
+        'Reusable introduction',
+        'Contents of text resources (partials) must be loaded in the catalog',
+      )
+
+      const image = contentCatalog.findBy({ family: 'image' })[0]
+      assert.strictEqual(
+        image !== undefined,
+        true,
+        'Image must be present in the content catalog',
+      )
+      assert.strictEqual(
+        image.contents.length,
+        0,
+        'Contents of binary resources (images) must not be loaded in the catalog',
+      )
+    } finally {
+      await removeFiles(createdFiles)
+      await resetAntoraSupport()
+    }
+  })
+
+  test('Should resolve a resource id to its absolute path', async () => {
+    const createdFiles = []
+    try {
+      createdFiles.push(await createDirectory('modules'))
+      await createDirectories('modules', 'ROOT', 'pages')
+      const asciidocFile = await createFile(
+        'image:mountain.jpeg[]',
+        'modules',
+        'ROOT',
+        'pages',
+        'landscape.adoc',
+      )
+      createdFiles.push(asciidocFile)
+      const imageFile = await createFile(
+        '',
+        'modules',
+        'ROOT',
+        'images',
+        'mountain.jpeg',
+      )
+      createdFiles.push(imageFile)
+      createdFiles.push(
+        await createFile(`name: ROOT\nversion: ~\n`, 'antora.yml'),
+      )
+      await enableAntoraSupport()
+      const result = await getAntoraDocumentContext(
+        asciidocFile,
+        extensionContext.workspaceState,
+      )
+      const resolved = result.resolveAntoraResourceIds('mountain.jpeg', 'image')
+      assert.strictEqual(
+        resolved,
+        imageFile.path,
+        'Resource id must resolve to the absolute path of the image',
+      )
+    } finally {
+      await removeFiles(createdFiles)
+      await resetAntoraSupport()
+    }
+  })
+})
+
+describe('Antora content catalog caching', () => {
+  async function createSingleComponent(createdFiles: vscode.Uri[]) {
+    createdFiles.push(await createDirectory('modules'))
+    await createDirectories('modules', 'ROOT', 'pages')
+    const asciidocFile = await createFile(
+      '= Landscape',
+      'modules',
+      'ROOT',
+      'pages',
+      'landscape.adoc',
+    )
+    createdFiles.push(asciidocFile)
+    createdFiles.push(
+      await createFile(`name: ROOT\nversion: ~\n`, 'antora.yml'),
+    )
+    return asciidocFile
+  }
+
+  test('Should reuse the cached content catalog across calls', async () => {
+    const createdFiles = []
+    try {
+      const asciidocFile = await createSingleComponent(createdFiles)
+      await enableAntoraSupport()
+      const workspaceState = extensionContext.workspaceState
+      const first = await getAntoraDocumentContext(asciidocFile, workspaceState)
+      const second = await getAntoraDocumentContext(
+        asciidocFile,
+        workspaceState,
+      )
+      assert.strictEqual(
+        first.getContentCatalog(),
+        second.getContentCatalog(),
+        'The content catalog must be reused from the cache between calls',
+      )
+    } finally {
+      await removeFiles(createdFiles)
+      await resetAntoraSupport()
+    }
+  })
+
+  test('Should rebuild the content catalog after the cache is cleared', async () => {
+    const createdFiles = []
+    try {
+      const asciidocFile = await createSingleComponent(createdFiles)
+      await enableAntoraSupport()
+      const workspaceState = extensionContext.workspaceState
+      const first = await getAntoraDocumentContext(asciidocFile, workspaceState)
+      clearAntoraCache()
+      const second = await getAntoraDocumentContext(
+        asciidocFile,
+        workspaceState,
+      )
+      assert.notStrictEqual(
+        first.getContentCatalog(),
+        second.getContentCatalog(),
+        'The content catalog must be rebuilt once the cache is invalidated',
+      )
     } finally {
       await removeFiles(createdFiles)
       await resetAntoraSupport()

--- a/src/test/workspaceHelper.ts
+++ b/src/test/workspaceHelper.ts
@@ -5,9 +5,11 @@ import {
   getDefaultWorkspaceFolderUri,
   normalizeUri,
 } from '../core/workspace.js'
+import { clearAntoraCache } from '../features/antora/antoraDocument.js'
 import { extensionContext } from './helper.js'
 
 export async function removeFiles(files: vscode.Uri[]) {
+  clearAntoraCache()
   for (const file of files) {
     if (await exists(file)) {
       await vscode.workspace.fs.delete(file, { recursive: true })
@@ -37,6 +39,7 @@ export async function createFile(
     ...pathSegments,
   )
   await vscode.workspace.fs.writeFile(file, Buffer.from(content))
+  clearAntoraCache()
   return normalizeUri(file)
 }
 
@@ -93,10 +96,16 @@ export async function createLink(
 }
 
 export async function enableAntoraSupport() {
+  // The Antora caches are keyed on the workspace state and invalidated through
+  // file system watchers, which do not fire deterministically within a test
+  // run. Clear them explicitly so each scenario rebuilds from the files it just
+  // created.
+  clearAntoraCache()
   await extensionContext.workspaceState.update('antoraSupportSetting', true)
 }
 
 export async function resetAntoraSupport() {
+  clearAntoraCache()
   await extensionContext.workspaceState.update(
     'antoraSupportSetting',
     undefined,


### PR DESCRIPTION
Building the Antora content catalog used to glob the whole workspace and read every content file (including images) before running the content classifier, on every preview render — i.e. on virtually every keystroke. On large projects this made Antora support noticeably slow.

- Memoize the antora.yml URIs, parsed configs and content catalog, sharing in-flight promises so concurrent renders reuse a single build.
- Invalidate the caches through file system watchers on `**/antora.yml` and `**/modules/**`.
- Stop loading the bytes of binary resources (images, attachments, assets) into the catalog; only text families (pages, partials, examples) need their contents.

Add tests covering catalog construction (text contents loaded, binary contents skipped, resource id resolution) and cache behavior (reuse across calls, rebuild after invalidation).