### PR TITLE
test(completion): unit-test pure completion logic in vscode-free modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Infrastructure
 
+* Extract the pure completion logic (Antora resource id forms, Antora resource macro matching, xref/`<<` anchor id extraction) into `vscode`-free modules and cover it with fast Node `test:unit` unit tests instead of the extension-host suite (#434)
 * Migrate from webpack to esbuild
 * Switch Node.js extension output to `.mjs` and remove `"type": "module"` from `package.json` to prevent VS Code web worker host from misidentifying the CJS browser bundle as ESM
 * Migrate to Asciidoctor.js 4.0.x (#999)

--- a/src/features/antora/antoraResourceCompletionProvider.ts
+++ b/src/features/antora/antoraResourceCompletionProvider.ts
@@ -1,99 +1,20 @@
 import * as vscode from 'vscode'
-import type { AntoraResourceContext } from './antoraContext.js'
 import { getAntoraDocumentContext } from './antoraDocument.js'
+import {
+  buildResourceIds,
+  findAntoraResourceMacroPrefix,
+} from './antoraResourceId.js'
 
-// Matches a macro and the resource id typed so far, anchored at the cursor, e.g.
-// `image::ui:but` while completing `image::ui:button.png[]`.
-const MACRO_PREFIX_RX = /\b(image|xref|include)(::?)([^\s[\]]*)$/
-
-interface MacroCompletionContext {
-  macro: 'image' | 'xref' | 'include'
-  /** The families to suggest for this macro. */
-  families: string[]
-  /** The default family of the macro (omitted from the generated ids). */
-  defaultFamily: string
-  /** Column where the resource id starts on the current line. */
-  targetStart: number
-}
-
-const MACRO_SETTINGS: {
-  [macro: string]: { families: string[]; defaultFamily: string }
-} = {
-  image: { families: ['image'], defaultFamily: 'image' },
-  xref: { families: ['page'], defaultFamily: 'page' },
-  include: { families: ['partial', 'example', 'page'], defaultFamily: 'page' },
-}
+// Re-exported so existing importers keep resolving these helpers from the
+// provider; the implementation now lives in the vscode-free `antoraResourceId`
+// module so it can be unit-tested without the extension host.
+export { buildResourceIds, findAntoraResourceMacroPrefix }
 
 const KIND_BY_FAMILY: { [family: string]: vscode.CompletionItemKind } = {
   image: vscode.CompletionItemKind.File,
   page: vscode.CompletionItemKind.Reference,
   partial: vscode.CompletionItemKind.Reference,
   example: vscode.CompletionItemKind.Reference,
-}
-
-export function findAntoraResourceMacroPrefix(
-  lineTextBeforeCursor: string,
-): MacroCompletionContext | undefined {
-  const match = MACRO_PREFIX_RX.exec(lineTextBeforeCursor)
-  if (match === null) {
-    return undefined
-  }
-  const macro = match[1] as 'image' | 'xref' | 'include'
-  const settings = MACRO_SETTINGS[macro]
-  return {
-    macro,
-    families: settings.families,
-    defaultFamily: settings.defaultFamily,
-    targetStart: match.index + match[1].length + match[2].length,
-  }
-}
-
-/**
- * Build every valid resource id that points at `target` from the `current` page
- * context, following Antora's resource id coordinates
- * `version@component:module:family$relative`, from the shortest unambiguous form
- * to the fully qualified one. For example, an image of the same module yields
- * `seaswell.png`, `commands:seaswell.png`, `cli:commands:seaswell.png` and
- * `2.0@cli:commands:seaswell.png`.
- */
-export function buildResourceIds(
-  target: {
-    component: string
-    version: string
-    module: string
-    family: string
-    relative: string
-  },
-  current: AntoraResourceContext,
-  defaultFamily: string,
-): string[] {
-  const familyPrefix =
-    target.family === defaultFamily ? '' : `${target.family}$`
-  const relative = `${familyPrefix}${target.relative}`
-  // The ROOT module is referenced with an empty module segment.
-  const moduleSegment = target.module === 'ROOT' ? '' : target.module
-  const sameComponent = target.component === current.component
-  const sameVersion = target.version === current.version
-  const sameModule = target.module === current.module
-
-  const ids: string[] = []
-  // Shortest: just the relative path, valid within the same module.
-  if (sameComponent && sameVersion && sameModule) {
-    ids.push(relative)
-  }
-  // Module-qualified, valid within the same component and version.
-  if (sameComponent && sameVersion && (!sameModule || moduleSegment !== '')) {
-    ids.push(`${moduleSegment}:${relative}`)
-  }
-  // Component/module-qualified (version is optional).
-  ids.push(`${target.component}:${moduleSegment}:${relative}`)
-  // Fully qualified, including the version.
-  if (target.version) {
-    ids.push(
-      `${target.version}@${target.component}:${moduleSegment}:${relative}`,
-    )
-  }
-  return [...new Set(ids)]
 }
 
 /**

--- a/src/features/antora/antoraResourceDefinitionProvider.ts
+++ b/src/features/antora/antoraResourceDefinitionProvider.ts
@@ -1,18 +1,6 @@
 import * as vscode from 'vscode'
 import { getAntoraDocumentContext } from './antoraDocument.js'
-
-// Matches the `image:`/`image::`, `xref:` and `include::` macros and captures
-// their target, e.g. `image::2.0@cli:commands:output.png[]`.
-const MACRO_RX = /(image|xref|include)(::?)([^\s[\]]+)\[/g
-
-// An Antora resource id always carries a family/component/module/version marker.
-const RESOURCE_ID_DETECTOR_RX = /[$:@]/
-
-const DEFAULT_FAMILY_BY_MACRO: { [macro: string]: string } = {
-  image: 'image',
-  xref: 'page',
-  include: 'page',
-}
+import { matchAntoraResourceMacroAt } from './antoraResourceMacro.js'
 
 export interface AntoraResourceMacro {
   /** The resource id to resolve, without any `#fragment`. */
@@ -32,36 +20,18 @@ export function findAntoraResourceMacroAt(
   lineNumber: number,
   character: number,
 ): AntoraResourceMacro | undefined {
-  for (const match of lineText.matchAll(MACRO_RX)) {
-    const macro = match[1]
-    const target = match[3]
-    const targetStart = match.index + match[1].length + match[2].length
-    const targetEnd = targetStart + target.length
-    if (character < targetStart || character > targetEnd) {
-      continue
-    }
-    // Drop the fragment (e.g. `xref:page.adoc#anchor[]`) before resolution.
-    const fragmentIndex = target.indexOf('#')
-    const id = fragmentIndex === -1 ? target : target.slice(0, fragmentIndex)
-    if (id.length === 0) {
-      continue
-    }
-    // For includes, only resource ids go through the content catalog; plain
-    // relative paths are resolved by the include processor at render time.
-    if (macro === 'include' && !RESOURCE_ID_DETECTOR_RX.test(id)) {
-      continue
-    }
-    const idEnd = fragmentIndex === -1 ? targetEnd : targetStart + fragmentIndex
-    return {
-      id,
-      family: DEFAULT_FAMILY_BY_MACRO[macro],
-      range: new vscode.Range(
-        new vscode.Position(lineNumber, targetStart),
-        new vscode.Position(lineNumber, idEnd),
-      ),
-    }
+  const match = matchAntoraResourceMacroAt(lineText, character)
+  if (match === undefined) {
+    return undefined
   }
-  return undefined
+  return {
+    id: match.id,
+    family: match.family,
+    range: new vscode.Range(
+      new vscode.Position(lineNumber, match.idStart),
+      new vscode.Position(lineNumber, match.idEnd),
+    ),
+  }
 }
 
 function abspathToUri(abspath: string): vscode.Uri {

--- a/src/features/antora/antoraResourceId.ts
+++ b/src/features/antora/antoraResourceId.ts
@@ -1,0 +1,88 @@
+import type { AntoraResourceContext } from './antoraContext.js'
+
+// Matches a macro and the resource id typed so far, anchored at the cursor, e.g.
+// `image::ui:but` while completing `image::ui:button.png[]`.
+const MACRO_PREFIX_RX = /\b(image|xref|include)(::?)([^\s[\]]*)$/
+
+export interface MacroCompletionContext {
+  macro: 'image' | 'xref' | 'include'
+  /** The families to suggest for this macro. */
+  families: string[]
+  /** The default family of the macro (omitted from the generated ids). */
+  defaultFamily: string
+  /** Column where the resource id starts on the current line. */
+  targetStart: number
+}
+
+const MACRO_SETTINGS: {
+  [macro: string]: { families: string[]; defaultFamily: string }
+} = {
+  image: { families: ['image'], defaultFamily: 'image' },
+  xref: { families: ['page'], defaultFamily: 'page' },
+  include: { families: ['partial', 'example', 'page'], defaultFamily: 'page' },
+}
+
+export function findAntoraResourceMacroPrefix(
+  lineTextBeforeCursor: string,
+): MacroCompletionContext | undefined {
+  const match = MACRO_PREFIX_RX.exec(lineTextBeforeCursor)
+  if (match === null) {
+    return undefined
+  }
+  const macro = match[1] as 'image' | 'xref' | 'include'
+  const settings = MACRO_SETTINGS[macro]
+  return {
+    macro,
+    families: settings.families,
+    defaultFamily: settings.defaultFamily,
+    targetStart: match.index + match[1].length + match[2].length,
+  }
+}
+
+/**
+ * Build every valid resource id that points at `target` from the `current` page
+ * context, following Antora's resource id coordinates
+ * `version@component:module:family$relative`, from the shortest unambiguous form
+ * to the fully qualified one. For example, an image of the same module yields
+ * `seaswell.png`, `commands:seaswell.png`, `cli:commands:seaswell.png` and
+ * `2.0@cli:commands:seaswell.png`.
+ */
+export function buildResourceIds(
+  target: {
+    component: string
+    version: string
+    module: string
+    family: string
+    relative: string
+  },
+  current: AntoraResourceContext,
+  defaultFamily: string,
+): string[] {
+  const familyPrefix =
+    target.family === defaultFamily ? '' : `${target.family}$`
+  const relative = `${familyPrefix}${target.relative}`
+  // The ROOT module is referenced with an empty module segment.
+  const moduleSegment = target.module === 'ROOT' ? '' : target.module
+  const sameComponent = target.component === current.component
+  const sameVersion = target.version === current.version
+  const sameModule = target.module === current.module
+
+  const ids: string[] = []
+  // Shortest: just the relative path, valid within the same module.
+  if (sameComponent && sameVersion && sameModule) {
+    ids.push(relative)
+  }
+  // Module-qualified, valid within the same component and version.
+  if (sameComponent && sameVersion && (!sameModule || moduleSegment !== '')) {
+    ids.push(`${moduleSegment}:${relative}`)
+  }
+  // Component/module-qualified (version is optional).
+  ids.push(`${target.component}:${moduleSegment}:${relative}`)
+  // Fully qualified, including the version.
+  if (target.version) {
+    ids.push(
+      `${target.version}@${target.component}:${moduleSegment}:${relative}`,
+    )
+  }
+  return [...new Set(ids)]
+}

--- a/src/features/antora/antoraResourceMacro.ts
+++ b/src/features/antora/antoraResourceMacro.ts
@@ -1,0 +1,62 @@
+// Matches the `image:`/`image::`, `xref:` and `include::` macros and captures
+// their target, e.g. `image::2.0@cli:commands:output.png[]`.
+const MACRO_RX = /(image|xref|include)(::?)([^\s[\]]+)\[/g
+
+// An Antora resource id always carries a family/component/module/version marker.
+const RESOURCE_ID_DETECTOR_RX = /[$:@]/
+
+const DEFAULT_FAMILY_BY_MACRO: { [macro: string]: string } = {
+  image: 'image',
+  xref: 'page',
+  include: 'page',
+}
+
+export interface AntoraResourceMacroMatch {
+  /** The resource id to resolve, without any `#fragment`. */
+  id: string
+  /** The default Antora family to assume when the id does not specify one. */
+  family: string
+  /** Column where the resource id starts on the line. */
+  idStart: number
+  /** Column right after the resource id (before any `#fragment`). */
+  idEnd: number
+}
+
+/**
+ * Find the Antora resource macro whose target is located under `character` on
+ * the given line, if any. Returns plain string offsets so the matcher stays free
+ * of any `vscode` dependency and can be unit-tested in isolation.
+ */
+export function matchAntoraResourceMacroAt(
+  lineText: string,
+  character: number,
+): AntoraResourceMacroMatch | undefined {
+  for (const match of lineText.matchAll(MACRO_RX)) {
+    const macro = match[1]
+    const target = match[3]
+    const targetStart = match.index + match[1].length + match[2].length
+    const targetEnd = targetStart + target.length
+    if (character < targetStart || character > targetEnd) {
+      continue
+    }
+    // Drop the fragment (e.g. `xref:page.adoc#anchor[]`) before resolution.
+    const fragmentIndex = target.indexOf('#')
+    const id = fragmentIndex === -1 ? target : target.slice(0, fragmentIndex)
+    if (id.length === 0) {
+      continue
+    }
+    // For includes, only resource ids go through the content catalog; plain
+    // relative paths are resolved by the include processor at render time.
+    if (macro === 'include' && !RESOURCE_ID_DETECTOR_RX.test(id)) {
+      continue
+    }
+    const idEnd = fragmentIndex === -1 ? targetEnd : targetStart + fragmentIndex
+    return {
+      id,
+      family: DEFAULT_FAMILY_BY_MACRO[macro],
+      idStart: targetStart,
+      idEnd,
+    }
+  }
+  return undefined
+}

--- a/src/features/completion/xrefCompletionProvider.ts
+++ b/src/features/completion/xrefCompletionProvider.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path'
 import * as vscode from 'vscode'
 import { findFiles } from '../../core/findFiles.js'
 import { Context, createContext } from './createContext.js'
+import { getIdsFromContent } from './xrefIdExtractor.js'
 
 export const xrefProvider = {
   provideCompletionItems,
@@ -36,46 +37,7 @@ function shouldProvide(context: Context, keyword: string): boolean {
 async function getIdsFromFile(file: vscode.Uri) {
   const data = await vscode.workspace.fs.readFile(file)
   const content = Buffer.from(data).toString('utf8')
-  const labelsFromLegacyBlock = await getLabelsFromLegacyBlock(content)
-  const labelsFromShorthandNotation =
-    await getLabelsFromShorthandNotation(content)
-  const labelsFromLonghandNotation =
-    await getLabelsFromLonghandNotation(content)
-  return labelsFromLegacyBlock.concat(
-    labelsFromShorthandNotation,
-    labelsFromLonghandNotation,
-  )
-}
-
-async function getLabelsFromLonghandNotation(
-  content: string,
-): Promise<string[]> {
-  const regex = /\[id=(\w+)\]/g
-  const matched = content.match(regex)
-  if (matched) {
-    return matched.map((result) => result.replace('[id=', '').replace(']', ''))
-  }
-  return []
-}
-
-async function getLabelsFromShorthandNotation(
-  content: string,
-): Promise<string[]> {
-  const regex = /\[#(\w+)\]/g
-  const matched = content.match(regex)
-  if (matched) {
-    return matched.map((result) => result.replace('[#', '').replace(']', ''))
-  }
-  return []
-}
-
-async function getLabelsFromLegacyBlock(content: string): Promise<string[]> {
-  const regex = /\[\[(\w+)\]\]/g
-  const matched = content.match(regex)
-  if (matched) {
-    return matched.map((result) => result.replace('[[', '').replace(']]', ''))
-  }
-  return []
+  return getIdsFromContent(content)
 }
 
 /**

--- a/src/features/completion/xrefIdExtractor.ts
+++ b/src/features/completion/xrefIdExtractor.ts
@@ -1,0 +1,40 @@
+// Pure extractors for the anchor ids declared in an AsciiDoc document, used to
+// feed xref/`<<` completion. Kept free of any `vscode` dependency so they can be
+// unit-tested in isolation.
+
+/** Ids declared with the legacy block anchor syntax, e.g. `[[anId]]`. */
+export function getLabelsFromLegacyBlock(content: string): string[] {
+  return matchIds(content, /\[\[(\w+)\]\]/g, '[[', ']]')
+}
+
+/** Ids declared with the shorthand syntax, e.g. `[#anId]`. */
+export function getLabelsFromShorthandNotation(content: string): string[] {
+  return matchIds(content, /\[#(\w+)\]/g, '[#', ']')
+}
+
+/** Ids declared with the longhand syntax, e.g. `[id=anId]`. */
+export function getLabelsFromLonghandNotation(content: string): string[] {
+  return matchIds(content, /\[id=(\w+)\]/g, '[id=', ']')
+}
+
+/** Every anchor id declared in `content`, across all supported syntaxes. */
+export function getIdsFromContent(content: string): string[] {
+  return [
+    ...getLabelsFromLegacyBlock(content),
+    ...getLabelsFromShorthandNotation(content),
+    ...getLabelsFromLonghandNotation(content),
+  ]
+}
+
+function matchIds(
+  content: string,
+  regex: RegExp,
+  open: string,
+  close: string,
+): string[] {
+  const matched = content.match(regex)
+  if (matched) {
+    return matched.map((result) => result.replace(open, '').replace(close, ''))
+  }
+  return []
+}

--- a/src/test/antoraResourceCompletionProvider.test.ts
+++ b/src/test/antoraResourceCompletionProvider.test.ts
@@ -2,11 +2,10 @@ import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 import * as vscode from 'vscode'
 import { Position } from 'vscode'
-import {
-  AntoraResourceCompletionProvider,
-  buildResourceIds,
-  findAntoraResourceMacroPrefix,
-} from '../features/antora/antoraResourceCompletionProvider.js'
+// Note: the pure helpers `buildResourceIds` and `findAntoraResourceMacroPrefix`
+// are unit-tested in `test/unit/antoraResourceId.test.ts`; this suite only
+// covers the provider's integration with the extension host.
+import { AntoraResourceCompletionProvider } from '../features/antora/antoraResourceCompletionProvider.js'
 import { extensionContext } from './helper.js'
 import {
   createDirectories,
@@ -16,119 +15,6 @@ import {
   removeFiles,
   resetAntoraSupport,
 } from './workspaceHelper.js'
-
-const current = { component: 'docs', version: '1.0', module: 'ROOT' }
-
-describe('buildResourceIds', () => {
-  test('Should offer the relative, module, component and version forms within the same module', () => {
-    const ids = buildResourceIds(
-      {
-        component: 'cli',
-        version: '2.0',
-        module: 'commands',
-        family: 'image',
-        relative: 'seaswell.png',
-      },
-      { component: 'cli', version: '2.0', module: 'commands' },
-      'image',
-    )
-    assert.deepStrictEqual(ids, [
-      'seaswell.png',
-      'commands:seaswell.png',
-      'cli:commands:seaswell.png',
-      '2.0@cli:commands:seaswell.png',
-    ])
-  })
-
-  test('Should offer module-qualified forms for another module of the same component', () => {
-    const ids = buildResourceIds(
-      { ...current, module: 'ui', family: 'image', relative: 'button.png' },
-      current,
-      'image',
-    )
-    assert.deepStrictEqual(ids, [
-      'ui:button.png',
-      'docs:ui:button.png',
-      '1.0@docs:ui:button.png',
-    ])
-  })
-
-  test('Should use an empty module segment for the ROOT module', () => {
-    const ids = buildResourceIds(
-      { ...current, family: 'image', relative: 'logo.png' },
-      { component: 'docs', version: '1.0', module: 'ui' },
-      'image',
-    )
-    assert.deepStrictEqual(ids, [
-      ':logo.png',
-      'docs::logo.png',
-      '1.0@docs::logo.png',
-    ])
-  })
-
-  test('Should only offer component/version forms for another component', () => {
-    const ids = buildResourceIds(
-      {
-        component: 'api',
-        version: '1.0',
-        module: 'auth',
-        family: 'page',
-        relative: 'page3.adoc',
-      },
-      current,
-      'page',
-    )
-    assert.deepStrictEqual(ids, [
-      'api:auth:page3.adoc',
-      '1.0@api:auth:page3.adoc',
-    ])
-  })
-
-  test('Should prefix the family when it is not the default of the macro', () => {
-    const ids = buildResourceIds(
-      { ...current, family: 'partial', relative: 'intro.adoc' },
-      current,
-      'page',
-    )
-    assert.deepStrictEqual(ids, [
-      'partial$intro.adoc',
-      'docs::partial$intro.adoc',
-      '1.0@docs::partial$intro.adoc',
-    ])
-  })
-})
-
-describe('findAntoraResourceMacroPrefix', () => {
-  test('Should detect a block image macro', () => {
-    const context = findAntoraResourceMacroPrefix('image::')
-    assert.strictEqual(context?.macro, 'image')
-    assert.strictEqual(context?.targetStart, 7)
-  })
-
-  test('Should detect an inline image macro', () => {
-    const context = findAntoraResourceMacroPrefix('image:')
-    assert.strictEqual(context?.macro, 'image')
-    assert.strictEqual(context?.targetStart, 6)
-  })
-
-  test('Should detect a macro preceded by text and a partial target', () => {
-    const context = findAntoraResourceMacroPrefix('see image::ui:but')
-    assert.strictEqual(context?.macro, 'image')
-    assert.strictEqual(context?.targetStart, 11)
-  })
-
-  test('Should suggest partials, examples and pages for include', () => {
-    const context = findAntoraResourceMacroPrefix('include::')
-    assert.deepStrictEqual(context?.families, ['partial', 'example', 'page'])
-  })
-
-  test('Should return undefined outside of a resource macro', () => {
-    assert.strictEqual(
-      findAntoraResourceMacroPrefix('just some text'),
-      undefined,
-    )
-  })
-})
 
 describe('AntoraResourceCompletionProvider', () => {
   async function createComponent(createdFiles: vscode.Uri[]) {

--- a/src/test/antoraResourceDefinitionProvider.test.ts
+++ b/src/test/antoraResourceDefinitionProvider.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 import * as vscode from 'vscode'
 import { CancellationTokenSource, Position } from 'vscode'
-import {
-  AntoraResourceDefinitionProvider,
-  findAntoraResourceMacroAt,
-} from '../features/antora/antoraResourceDefinitionProvider.js'
+// Note: the pure `findAntoraResourceMacroAt` matching logic is unit-tested in
+// `test/unit/antoraResourceMacro.test.ts`; this suite only covers the provider's
+// integration with the extension host.
+import { AntoraResourceDefinitionProvider } from '../features/antora/antoraResourceDefinitionProvider.js'
 import { extensionContext } from './helper.js'
 import {
   createDirectories,
@@ -15,48 +15,6 @@ import {
   removeFiles,
   resetAntoraSupport,
 } from './workspaceHelper.js'
-
-describe('findAntoraResourceMacroAt', () => {
-  test('Should detect an inline image resource id under the cursor', () => {
-    const line = 'image:commands:output.png[]'
-    const macro = findAntoraResourceMacroAt(line, 0, 10)
-    assert.strictEqual(macro?.id, 'commands:output.png')
-    assert.strictEqual(macro?.family, 'image')
-  })
-
-  test('Should detect a block image resource id with version and component', () => {
-    const line = 'image::2.0@cli:commands:output.png[]'
-    const macro = findAntoraResourceMacroAt(line, 0, 12)
-    assert.strictEqual(macro?.id, '2.0@cli:commands:output.png')
-    assert.strictEqual(macro?.family, 'image')
-  })
-
-  test('Should drop the fragment of an xref resource id', () => {
-    const line = 'xref:page.adoc#anchor[text]'
-    const macro = findAntoraResourceMacroAt(line, 0, 8)
-    assert.strictEqual(macro?.id, 'page.adoc')
-    assert.strictEqual(macro?.family, 'page')
-  })
-
-  test('Should ignore a plain relative include path', () => {
-    const line = 'include::intro.adoc[]'
-    const macro = findAntoraResourceMacroAt(line, 0, 12)
-    assert.strictEqual(macro, undefined)
-  })
-
-  test('Should detect a partial include resource id', () => {
-    const line = 'include::partial$intro.adoc[]'
-    const macro = findAntoraResourceMacroAt(line, 0, 15)
-    assert.strictEqual(macro?.id, 'partial$intro.adoc')
-    assert.strictEqual(macro?.family, 'page')
-  })
-
-  test('Should return undefined when the cursor is outside the target', () => {
-    const line = 'image::output.png[]'
-    // cursor on the `image` keyword, before the target
-    assert.strictEqual(findAntoraResourceMacroAt(line, 0, 2), undefined)
-  })
-})
 
 describe('AntoraResourceDefinitionProvider', () => {
   test('Should resolve an image resource id to its file', async () => {

--- a/src/test/unit/antoraResourceId.test.ts
+++ b/src/test/unit/antoraResourceId.test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  buildResourceIds,
+  findAntoraResourceMacroPrefix,
+} from '../../features/antora/antoraResourceId.js'
+
+const current = { component: 'docs', version: '1.0', module: 'ROOT' }
+
+describe('buildResourceIds', () => {
+  test('Should offer the relative, module, component and version forms within the same module', () => {
+    const ids = buildResourceIds(
+      {
+        component: 'cli',
+        version: '2.0',
+        module: 'commands',
+        family: 'image',
+        relative: 'seaswell.png',
+      },
+      { component: 'cli', version: '2.0', module: 'commands' },
+      'image',
+    )
+    assert.deepStrictEqual(ids, [
+      'seaswell.png',
+      'commands:seaswell.png',
+      'cli:commands:seaswell.png',
+      '2.0@cli:commands:seaswell.png',
+    ])
+  })
+
+  test('Should offer module-qualified forms for another module of the same component', () => {
+    const ids = buildResourceIds(
+      { ...current, module: 'ui', family: 'image', relative: 'button.png' },
+      current,
+      'image',
+    )
+    assert.deepStrictEqual(ids, [
+      'ui:button.png',
+      'docs:ui:button.png',
+      '1.0@docs:ui:button.png',
+    ])
+  })
+
+  test('Should use an empty module segment for the ROOT module', () => {
+    const ids = buildResourceIds(
+      { ...current, family: 'image', relative: 'logo.png' },
+      { component: 'docs', version: '1.0', module: 'ui' },
+      'image',
+    )
+    assert.deepStrictEqual(ids, [
+      ':logo.png',
+      'docs::logo.png',
+      '1.0@docs::logo.png',
+    ])
+  })
+
+  test('Should only offer component/version forms for another component', () => {
+    const ids = buildResourceIds(
+      {
+        component: 'api',
+        version: '1.0',
+        module: 'auth',
+        family: 'page',
+        relative: 'page3.adoc',
+      },
+      current,
+      'page',
+    )
+    assert.deepStrictEqual(ids, [
+      'api:auth:page3.adoc',
+      '1.0@api:auth:page3.adoc',
+    ])
+  })
+
+  test('Should prefix the family when it is not the default of the macro', () => {
+    const ids = buildResourceIds(
+      { ...current, family: 'partial', relative: 'intro.adoc' },
+      current,
+      'page',
+    )
+    assert.deepStrictEqual(ids, [
+      'partial$intro.adoc',
+      'docs::partial$intro.adoc',
+      '1.0@docs::partial$intro.adoc',
+    ])
+  })
+
+  test('Should omit the version forms when the target has no version', () => {
+    const ids = buildResourceIds(
+      {
+        component: 'docs',
+        version: '',
+        module: 'ROOT',
+        family: 'page',
+        relative: 'index.adoc',
+      },
+      { component: 'docs', version: '', module: 'ROOT' },
+      'page',
+    )
+    assert.deepStrictEqual(ids, ['index.adoc', 'docs::index.adoc'])
+  })
+})
+
+describe('findAntoraResourceMacroPrefix', () => {
+  test('Should detect a block image macro', () => {
+    const context = findAntoraResourceMacroPrefix('image::')
+    assert.strictEqual(context?.macro, 'image')
+    assert.strictEqual(context?.targetStart, 7)
+  })
+
+  test('Should detect an inline image macro', () => {
+    const context = findAntoraResourceMacroPrefix('image:')
+    assert.strictEqual(context?.macro, 'image')
+    assert.strictEqual(context?.targetStart, 6)
+  })
+
+  test('Should detect a macro preceded by text and a partial target', () => {
+    const context = findAntoraResourceMacroPrefix('see image::ui:but')
+    assert.strictEqual(context?.macro, 'image')
+    assert.strictEqual(context?.targetStart, 11)
+  })
+
+  test('Should only suggest pages for xref', () => {
+    const context = findAntoraResourceMacroPrefix('xref:')
+    assert.strictEqual(context?.macro, 'xref')
+    assert.deepStrictEqual(context?.families, ['page'])
+    assert.strictEqual(context?.defaultFamily, 'page')
+  })
+
+  test('Should suggest partials, examples and pages for include', () => {
+    const context = findAntoraResourceMacroPrefix('include::')
+    assert.deepStrictEqual(context?.families, ['partial', 'example', 'page'])
+  })
+
+  test('Should return undefined outside of a resource macro', () => {
+    assert.strictEqual(
+      findAntoraResourceMacroPrefix('just some text'),
+      undefined,
+    )
+  })
+
+  test('Should return undefined when the macro is not anchored at the cursor', () => {
+    // The id is already terminated by `[`, so the cursor is no longer typing it.
+    assert.strictEqual(
+      findAntoraResourceMacroPrefix('image::logo.png['),
+      undefined,
+    )
+  })
+})

--- a/src/test/unit/antoraResourceMacro.test.ts
+++ b/src/test/unit/antoraResourceMacro.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { matchAntoraResourceMacroAt } from '../../features/antora/antoraResourceMacro.js'
+
+describe('matchAntoraResourceMacroAt', () => {
+  test('Should detect an inline image resource id under the cursor', () => {
+    const line = 'image:commands:output.png[]'
+    const macro = matchAntoraResourceMacroAt(line, 10)
+    assert.strictEqual(macro?.id, 'commands:output.png')
+    assert.strictEqual(macro?.family, 'image')
+    assert.strictEqual(macro?.idStart, 6)
+    assert.strictEqual(macro?.idEnd, 25)
+  })
+
+  test('Should detect a block image resource id with version and component', () => {
+    const line = 'image::2.0@cli:commands:output.png[]'
+    const macro = matchAntoraResourceMacroAt(line, 12)
+    assert.strictEqual(macro?.id, '2.0@cli:commands:output.png')
+    assert.strictEqual(macro?.family, 'image')
+  })
+
+  test('Should drop the fragment of an xref resource id', () => {
+    const line = 'xref:page.adoc#anchor[text]'
+    const macro = matchAntoraResourceMacroAt(line, 8)
+    assert.strictEqual(macro?.id, 'page.adoc')
+    assert.strictEqual(macro?.family, 'page')
+    // The id range stops before the `#fragment`.
+    assert.strictEqual(macro?.idStart, 5)
+    assert.strictEqual(macro?.idEnd, 14)
+  })
+
+  test('Should ignore a plain relative include path', () => {
+    const line = 'include::intro.adoc[]'
+    assert.strictEqual(matchAntoraResourceMacroAt(line, 12), undefined)
+  })
+
+  test('Should detect a partial include resource id', () => {
+    const line = 'include::partial$intro.adoc[]'
+    const macro = matchAntoraResourceMacroAt(line, 15)
+    assert.strictEqual(macro?.id, 'partial$intro.adoc')
+    assert.strictEqual(macro?.family, 'page')
+  })
+
+  test('Should return undefined when the cursor is outside the target', () => {
+    const line = 'image::output.png[]'
+    // cursor on the `image` keyword, before the target
+    assert.strictEqual(matchAntoraResourceMacroAt(line, 2), undefined)
+  })
+
+  test('Should pick the macro under the cursor when several appear on the line', () => {
+    const line = 'image:first.png[] and image:second.png[]'
+    const macro = matchAntoraResourceMacroAt(line, 30)
+    assert.strictEqual(macro?.id, 'second.png')
+  })
+})

--- a/src/test/unit/xrefIdExtractor.test.ts
+++ b/src/test/unit/xrefIdExtractor.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  getIdsFromContent,
+  getLabelsFromLegacyBlock,
+  getLabelsFromLonghandNotation,
+  getLabelsFromShorthandNotation,
+} from '../../features/completion/xrefIdExtractor.js'
+
+describe('getLabelsFromLegacyBlock', () => {
+  test('Should extract every legacy double-bracket anchor', () => {
+    const content = '[[first]]\nsome text\n[[second]]'
+    assert.deepStrictEqual(getLabelsFromLegacyBlock(content), [
+      'first',
+      'second',
+    ])
+  })
+
+  test('Should return an empty array when there is no legacy anchor', () => {
+    assert.deepStrictEqual(getLabelsFromLegacyBlock('no anchors here'), [])
+  })
+
+  test('Should not match the shorthand or longhand syntaxes', () => {
+    assert.deepStrictEqual(
+      getLabelsFromLegacyBlock('[#shorthand]\n[id=longhand]'),
+      [],
+    )
+  })
+})
+
+describe('getLabelsFromShorthandNotation', () => {
+  test('Should extract every shorthand anchor', () => {
+    const content = '[#intro]\n== Title\n[#summary]'
+    assert.deepStrictEqual(getLabelsFromShorthandNotation(content), [
+      'intro',
+      'summary',
+    ])
+  })
+
+  test('Should return an empty array when there is no shorthand anchor', () => {
+    assert.deepStrictEqual(getLabelsFromShorthandNotation('[[legacy]]'), [])
+  })
+})
+
+describe('getLabelsFromLonghandNotation', () => {
+  test('Should extract every longhand anchor', () => {
+    const content = '[id=intro]\n== Title\n[id=summary]'
+    assert.deepStrictEqual(getLabelsFromLonghandNotation(content), [
+      'intro',
+      'summary',
+    ])
+  })
+
+  test('Should return an empty array when there is no longhand anchor', () => {
+    assert.deepStrictEqual(getLabelsFromLonghandNotation('[[legacy]]'), [])
+  })
+})
+
+describe('getIdsFromContent', () => {
+  test('Should collect ids across the legacy, shorthand and longhand syntaxes', () => {
+    const content = '[[legacy]]\n[#shorthand]\n[id=longhand]'
+    assert.deepStrictEqual(getIdsFromContent(content), [
+      'legacy',
+      'shorthand',
+      'longhand',
+    ])
+  })
+
+  test('Should return an empty array for a document without anchors', () => {
+    assert.deepStrictEqual(getIdsFromContent('= Title\n\nA paragraph.'), [])
+  })
+})


### PR DESCRIPTION
Extract the pure logic of the completion providers into modules that do not import `vscode` at runtime, so it can be covered by the fast Node `test:unit` harness (properly instrumented by c8) instead of the slow extension-host suite:

- antoraResourceId.ts: buildResourceIds + findAntoraResourceMacroPrefix
- antoraResourceMacro.ts: matchAntoraResourceMacroAt (returns offsets; findAntoraResourceMacroAt now wraps it to build the vscode.Range)
- xrefIdExtractor.ts: anchor id extractors (pure, synchronous)

Add unit tests for each module and drop the now-duplicated pure-function describe blocks from the extension-host suites.
