### PR TITLE
feat(antora): complete xref fragments and fix preview links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Add go-to-definition / Ctrl+click navigation on Antora resource ids in `image:`, `xref:` and `include::` macros (#434)
 * Add Antora-aware auto-completion of resource ids (pages, images, partials, examples) in `image:`, `xref:` and `include::` macros, sourced from the content catalog. Every valid form is offered, from the shortest relative path to the fully qualified id (e.g. `seaswell.png`, `commands:seaswell.png`, `cli:commands:seaswell.png`, `2.0@cli:commands:seaswell.png`), and selecting one completes the macro with its `[]` (#434)
 * Restrict `image::`/`image:` path completion to image files (png, jpg, jpeg, gif, svg, …) instead of listing every file such as `.adoc` pages
+* On Antora pages, stop the workspace-wide `xref:` file-path completion (e.g. `../../../../full.adoc#…`) that competed with the Antora resource id completion, leaving the Antora-aware provider as the sole contributor (#434)
+* Complete the anchors of the referenced page after `xref:<page>#` on Antora pages, sourced from the block ids declared in the target page (e.g. `xref:api:auth:page3.adoc#oauth`) (#434)
+* Resolve Antora `xref:` resource ids in the preview so cross-component/cross-module links (and their `#anchor`) navigate to the referenced page instead of producing a broken link (#434)
 
 ### Infrastructure
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCompletionItemProvider(
       selector,
       new AntoraResourceCompletionProvider(context.workspaceState),
-      ...[':', '$', '@', '/'],
+      ...[':', '$', '@', '/', '#'],
     ),
   )
   context.subscriptions.push(

--- a/src/features/antora/antoraContext.ts
+++ b/src/features/antora/antoraContext.ts
@@ -76,6 +76,21 @@ export class AntoraDocumentContext {
     return undefined
   }
 
+  /**
+   * Resolve a resource id to its content catalog entry. Unlike
+   * `resolveAntoraResourceIds`, this exposes the whole resource (including its
+   * loaded `contents`) so callers can, for example, read the anchors declared in
+   * a referenced page.
+   */
+  public resolveResource(id: string, defaultFamily: string): any | undefined {
+    return this.antoraContext.contentCatalog.resolveResource(
+      id,
+      this.resourceContext,
+      defaultFamily,
+      this.PERMITTED_FAMILIES,
+    )
+  }
+
   public getComponents() {
     return this.antoraContext.contentCatalog.getComponents()
   }

--- a/src/features/antora/antoraResourceCompletionProvider.ts
+++ b/src/features/antora/antoraResourceCompletionProvider.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode'
+import { getIdsFromContent } from '../completion/xrefIdExtractor.js'
+import { AntoraDocumentContext } from './antoraContext.js'
 import { getAntoraDocumentContext } from './antoraDocument.js'
 import {
   buildResourceIds,
@@ -43,6 +45,20 @@ export class AntoraResourceCompletionProvider
     if (antoraDocumentContext === undefined) {
       return []
     }
+    // Once a page resource id is followed by `#`, complete the anchors declared
+    // in the referenced page (e.g. `xref:api:auth:page3.adoc#oauth[]`) instead of
+    // other resource ids.
+    const targetTyped = lineTextBeforeCursor.slice(macroContext.targetStart)
+    const fragmentIndex = targetTyped.indexOf('#')
+    if (macroContext.macro === 'xref' && fragmentIndex !== -1) {
+      return this.provideFragments(
+        document,
+        position,
+        antoraDocumentContext,
+        targetTyped.slice(0, fragmentIndex),
+        macroContext.targetStart + fragmentIndex + 1,
+      )
+    }
     const current = antoraDocumentContext.resourceContext
     const contentCatalog = antoraDocumentContext.getContentCatalog()
     const replaceRange = new vscode.Range(
@@ -74,5 +90,45 @@ export class AntoraResourceCompletionProvider
       }
     }
     return items
+  }
+
+  /**
+   * Suggest the anchors (block ids) declared in the page referenced by `pageId`,
+   * so `xref:<page>#` completes with the fragments available in that page.
+   */
+  private provideFragments(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    antoraDocumentContext: AntoraDocumentContext,
+    pageId: string,
+    fragmentStart: number,
+  ): vscode.CompletionItem[] {
+    if (pageId.length === 0) {
+      return []
+    }
+    const resource = antoraDocumentContext.resolveResource(pageId, 'page')
+    const contents = resource?.contents
+    if (contents === undefined) {
+      return []
+    }
+    const lineText = document.lineAt(position.line).text
+    const hasClosingBracket = lineText.charAt(position.character) === '['
+    const replaceRange = new vscode.Range(
+      new vscode.Position(position.line, fragmentStart),
+      position,
+    )
+    const ids = getIdsFromContent(contents.toString())
+    return ids.map((id) => {
+      const item = new vscode.CompletionItem(
+        id,
+        vscode.CompletionItemKind.Reference,
+      )
+      item.detail = `anchor · ${pageId}`
+      item.range = replaceRange
+      item.insertText = hasClosingBracket
+        ? id
+        : new vscode.SnippetString(`${id}[$0]`)
+      return item
+    })
   }
 }

--- a/src/features/completion/completionProviders.ts
+++ b/src/features/completion/completionProviders.ts
@@ -6,7 +6,7 @@ import { AttributeReferenceProvider } from './attributeReferenceProvider.js'
 import { BibtexProvider } from './bibtexCompletionProvider.js'
 import { BuiltinDocumentAttributeProvider } from './builtinDocumentAttributeProvider.js'
 import { TargetPathCompletionProvider } from './targetPathCompletionProvider.js'
-import { xrefProvider } from './xrefCompletionProvider.js'
+import { XrefCompletionProvider } from './xrefCompletionProvider.js'
 
 export class AsciidocCompletionProviders {
   private readonly disposables: vscode.Disposable[] = []
@@ -25,7 +25,7 @@ export class AsciidocCompletionProviders {
       ),
       vscode.languages.registerCompletionItemProvider(
         asciidocDocumentSelector,
-        xrefProvider,
+        new XrefCompletionProvider(asciidocLoader.context.workspaceState),
         ...[':', '/'],
       ),
       vscode.languages.registerCompletionItemProvider(

--- a/src/features/completion/xrefCompletionProvider.ts
+++ b/src/features/completion/xrefCompletionProvider.ts
@@ -1,24 +1,39 @@
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 import { findFiles } from '../../core/findFiles.js'
+import { getAntoraDocumentContext } from '../antora/antoraDocument.js'
 import { Context, createContext } from './createContext.js'
 import { getIdsFromContent } from './xrefIdExtractor.js'
 
-export const xrefProvider = {
-  provideCompletionItems,
-}
+/**
+ * Completes `xref:` cross references (to files and their anchors) and `<<`
+ * internal references. On Antora pages, cross references use resource ids
+ * resolved against the content catalog, so the workspace-wide file-path
+ * suggestions produced here are noise; the `AntoraResourceCompletionProvider`
+ * takes over the `xref:` macro instead.
+ */
+export class XrefCompletionProvider implements vscode.CompletionItemProvider {
+  constructor(private readonly workspaceState: vscode.Memento) {}
 
-export async function provideCompletionItems(
-  document: vscode.TextDocument,
-  position: vscode.Position,
-): Promise<vscode.CompletionItem[]> {
-  const context = createContext(document, position)
-  if (shouldProvide(context, 'xref:')) {
-    return provideCrossRef(context)
-  } else if (shouldProvide(context, '<<')) {
-    return provideInternalRef(context)
-  } else {
-    return Promise.resolve([])
+  public async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): Promise<vscode.CompletionItem[]> {
+    const context = createContext(document, position)
+    if (shouldProvide(context, 'xref:')) {
+      const antoraDocumentContext = await getAntoraDocumentContext(
+        document.uri,
+        this.workspaceState,
+      )
+      if (antoraDocumentContext !== undefined) {
+        return []
+      }
+      return provideCrossRef(context)
+    } else if (shouldProvide(context, '<<')) {
+      return provideInternalRef(context)
+    } else {
+      return []
+    }
   }
 }
 

--- a/src/features/preview/asciidoctorWebViewConverter.ts
+++ b/src/features/preview/asciidoctorWebViewConverter.ts
@@ -251,7 +251,12 @@ export class AsciidoctorWebViewConverter {
       }
       if (node.type === 'xref') {
         const attrs = []
-        attrs.push(` href="${node.target}"`)
+        // On Antora pages, the target is a resource id (e.g.
+        // `api:auth:page3.adoc#oauth`) that the base converter leaves untouched,
+        // producing a broken link in the preview. Resolve it to the actual file
+        // so the link navigates to the referenced page (and anchor).
+        const href = this.resolveXrefHref(node.target)
+        attrs.push(` href="${href}"`)
 
         if (node.hasAttribute('id')) {
           attrs.push(` id="${node.id}"`)
@@ -263,7 +268,7 @@ export class AsciidoctorWebViewConverter {
           attrs.push(` title="${node.title}"`)
         }
 
-        attrs.push(` data-href="${node.target}"`)
+        attrs.push(` data-href="${href}"`)
 
         let text: string
 
@@ -334,6 +339,36 @@ export class AsciidoctorWebViewConverter {
       }
     }
     return await this.baseConverter.convert(node, transform)
+  }
+
+  /**
+   * Resolve an `xref:` target to a link that works inside the preview. On Antora
+   * pages the target is a resource id (e.g. `api:auth:page3.adoc#oauth`); resolve
+   * the page part to its file path so clicking the link opens the referenced page
+   * at the right anchor. Targets that are not Antora resource ids (plain relative
+   * paths, internal anchors) are returned unchanged.
+   */
+  private resolveXrefHref(target: string): string {
+    if (
+      this.antoraDocumentContext === undefined ||
+      typeof target !== 'string'
+    ) {
+      return target
+    }
+    const hashIndex = target.indexOf('#')
+    const id = hashIndex === -1 ? target : target.slice(0, hashIndex)
+    const fragment = hashIndex === -1 ? '' : target.slice(hashIndex)
+    if (id.length === 0) {
+      return target
+    }
+    const resourcePath = this.antoraDocumentContext.resolveAntoraResourceIds(
+      id,
+      'page',
+    )
+    if (resourcePath === undefined) {
+      return target
+    }
+    return `${resourcePath}${fragment}`
   }
 
   private generateMathJax(node, webviewResourceProvider, nonce) {

--- a/src/test/antoraResourceCompletionProvider.test.ts
+++ b/src/test/antoraResourceCompletionProvider.test.ts
@@ -145,6 +145,52 @@ describe('AntoraResourceCompletionProvider', () => {
     }
   })
 
+  test('Should suggest the anchors of the referenced page after "xref:<page>#"', async () => {
+    const createdFiles = []
+    try {
+      createdFiles.push(await createDirectory('modules'))
+      await createDirectories('modules', 'ROOT', 'pages')
+      const page = await createFile(
+        'xref:target.adoc#',
+        'modules',
+        'ROOT',
+        'pages',
+        'source.adoc',
+      )
+      createdFiles.push(page)
+      createdFiles.push(
+        await createFile(
+          '= Target\n\n[#oauth]\n== OAuth\n',
+          'modules',
+          'ROOT',
+          'pages',
+          'target.adoc',
+        ),
+      )
+      createdFiles.push(
+        await createFile(`name: docs\nversion: '1.0'\n`, 'antora.yml'),
+      )
+      await enableAntoraSupport()
+      const provider = new AntoraResourceCompletionProvider(
+        extensionContext.workspaceState,
+      )
+      const document = await vscode.workspace.openTextDocument(page)
+      const items = await provider.provideCompletionItems(
+        document,
+        new Position(0, 17), // right after the "#"
+      )
+      const labels = items.map((item) => item.label)
+      assert.strictEqual(
+        labels.includes('oauth'),
+        true,
+        'Must suggest the anchor declared in the referenced page',
+      )
+    } finally {
+      await removeFiles(createdFiles)
+      await resetAntoraSupport()
+    }
+  })
+
   test('Should not suggest anything when Antora support is disabled', async () => {
     const createdFiles = []
     try {

--- a/src/test/asciidoctorWebViewConverter.test.ts
+++ b/src/test/asciidoctorWebViewConverter.test.ts
@@ -297,6 +297,18 @@ include::docC.adoc[]`,
 </div>`,
     },
     {
+      title:
+        'Should resolve "xref:" Antora resource id to the referenced page and anchor',
+      filePath: ['docs', 'modules', 'ROOT', 'pages', 'dummy.adoc'],
+      input: 'xref:api:auth:page3.adoc#oauth[]',
+      antoraDocumentContext: createAntoraDocumentContextStub(
+        `${workspaceUri.path}/antora/multiComponents/api/modules/auth/pages/page3.adoc`,
+      ),
+      expected: `<div class="paragraph">
+<p><a href="${workspaceUri.path}/antora/multiComponents/api/modules/auth/pages/page3.adoc#oauth" data-href="${workspaceUri.path}/antora/multiComponents/api/modules/auth/pages/page3.adoc#oauth">api:auth:page3.adoc</a></p>
+</div>`,
+    },
+    {
       title: 'Should resolve "xref:" macro for internal cross reference',
       filePath: ['asciidoctorWebViewConverterTest.adoc'],
       input: `xref:_text_test[]

--- a/src/test/xrefCompletionProvider.test.ts
+++ b/src/test/xrefCompletionProvider.test.ts
@@ -3,14 +3,17 @@ import { afterEach, beforeEach, describe, test } from 'node:test'
 import * as vscode from 'vscode'
 import { Position } from 'vscode'
 import { getDefaultWorkspaceFolderUri } from '../core/workspace.js'
-import { xrefProvider } from '../features/completion/xrefCompletionProvider.js'
+import { XrefCompletionProvider } from '../features/completion/xrefCompletionProvider.js'
+import { extensionContext } from './helper.js'
 
 let workspaceUri: vscode.Uri
 
 describe('Xref CompletionsProvider', () => {
   let createdFiles: vscode.Uri[] = []
+  let xrefProvider: XrefCompletionProvider
   beforeEach(() => {
     workspaceUri = getDefaultWorkspaceFolderUri()
+    xrefProvider = new XrefCompletionProvider(extensionContext.workspaceState)
   })
   afterEach(async () => {
     for (const createdFile of createdFiles) {


### PR DESCRIPTION
On Antora pages the legacy xref completion globbed the whole workspace and proposed file-path forms (e.g. `../../../../full.adoc#…`) that competed with the Antora resource id completion. Short-circuit it on Antora pages so the Antora-aware provider is the sole contributor for `xref:`.

Complete the anchors of the referenced page after `xref:<page>#`, sourced from the block ids declared in the target page (`[[..]]`, `[#..]`, `[id=..]`), and trigger on `#`.

Resolve Antora `xref:` resource ids in the preview converter so cross-component/cross-module links (and their `#anchor`) navigate to the referenced page instead of producing a broken link.


Ref #434 
