### PR TITLE
test(completion): unit-test xref/<< completion query parsing and label building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### Infrastructure
 
-* Extract the pure completion logic (Antora resource id forms, Antora resource macro matching, xref/`<<` anchor id extraction) into `vscode`-free modules and cover it with fast Node `test:unit` unit tests instead of the extension-host suite (#434)
+* Extract the pure completion logic (Antora resource id forms, Antora resource macro matching, xref/`<<` anchor id extraction, and the xref/`<<` query parsing and label building) into `vscode`-free modules and cover it with fast Node `test:unit` unit tests instead of the extension-host suite (#434)
 * Migrate from webpack to esbuild
 * Switch Node.js extension output to `.mjs` and remove `"type": "module"` from `package.json` to prevent VS Code web worker host from misidentifying the CJS browser bundle as ESM
 * Migrate to Asciidoctor.js 4.0.x (#999)

--- a/src/features/completion/xrefCompletion.ts
+++ b/src/features/completion/xrefCompletion.ts
@@ -1,0 +1,91 @@
+// Pure helpers backing the xref/`<<` completion. Kept free of any `vscode`
+// dependency so they can be unit-tested in isolation; the provider only wires
+// these to the editor (document lookup, file globbing, CompletionItem creation).
+
+import * as path from 'node:path'
+
+/**
+ * Whether `keyword` (e.g. `xref:` or `<<`) ends exactly at the cursor, i.e. the
+ * user just typed it and a completion should be offered.
+ */
+export function shouldProvideCompletion(
+  textFullLine: string,
+  character: number,
+  keyword: string,
+): boolean {
+  const occurrence = textFullLine.indexOf(keyword, character - keyword.length)
+  return occurrence === character - keyword.length
+}
+
+export interface CrossRefQuery {
+  /** The anchor id fragment typed after the macro, used to filter candidates. */
+  search: string
+  /** Whether the macro brackets (`[`) are already present after the cursor. */
+  hasBracket: boolean
+}
+
+/**
+ * Parse what the user typed right after `xref:` to drive cross reference
+ * completion: the id fragment to match and whether the brackets are present.
+ */
+export function parseCrossRefQuery(
+  textFullLine: string,
+  character: number,
+): CrossRefQuery {
+  const textLine = textFullLine.substring(character).split(' ')[0]
+  return {
+    search: textLine.split('[')[0],
+    hasBracket: textLine.includes('['),
+  }
+}
+
+/** Whether the anchor `label` matches the query typed after the macro. */
+export function matchesCrossRefQuery(label: string, search: string): boolean {
+  return !search || label.match(search) !== null
+}
+
+export interface CrossRefLabelPaths {
+  /** File system path of the document being edited. */
+  currentFilePath: string
+  /** File system path of the file declaring the anchor. */
+  targetFilePath: string
+}
+
+/**
+ * Build the completion label for an anchor reachable through `xref:`. Within the
+ * same file the bare id is used; otherwise it is prefixed with the path of the
+ * target file relative to the current document. The macro brackets are appended
+ * unless they are already typed.
+ */
+export function buildCrossRefLabel(
+  label: string,
+  hasBracket: boolean,
+  { currentFilePath, targetFilePath }: CrossRefLabelPaths,
+): string {
+  const labelText = hasBracket ? label : `${label}[]`
+  if (targetFilePath === currentFilePath) {
+    return labelText
+  }
+  const relativePath = path.relative(
+    path.dirname(currentFilePath),
+    targetFilePath,
+  )
+  return `${relativePath}#${labelText}`
+}
+
+/**
+ * Extract the id fragment typed after `<<` for internal cross references, used
+ * to filter the anchors declared in the current document.
+ */
+export function parseInternalRefQuery(
+  textFullLine: string,
+  character: number,
+): string {
+  const indexOfNextWhiteSpace = textFullLine.includes(' ', character)
+    ? textFullLine.indexOf(' ', character)
+    : textFullLine.length
+  return textFullLine.substring(
+    textFullLine.lastIndexOf('<', character + 1) + 1,
+    indexOfNextWhiteSpace,
+  )
+}

--- a/src/features/completion/xrefCompletionProvider.ts
+++ b/src/features/completion/xrefCompletionProvider.ts
@@ -1,8 +1,14 @@
-import * as path from 'node:path'
 import * as vscode from 'vscode'
 import { findFiles } from '../../core/findFiles.js'
 import { getAntoraDocumentContext } from '../antora/antoraDocument.js'
 import { Context, createContext } from './createContext.js'
+import {
+  buildCrossRefLabel,
+  matchesCrossRefQuery,
+  parseCrossRefQuery,
+  parseInternalRefQuery,
+  shouldProvideCompletion,
+} from './xrefCompletion.js'
 import { getIdsFromContent } from './xrefIdExtractor.js'
 
 /**
@@ -11,6 +17,9 @@ import { getIdsFromContent } from './xrefIdExtractor.js'
  * resolved against the content catalog, so the workspace-wide file-path
  * suggestions produced here are noise; the `AntoraResourceCompletionProvider`
  * takes over the `xref:` macro instead.
+ *
+ * The string parsing is delegated to the `vscode`-free helpers in
+ * `xrefCompletion`; this class only wires them to the editor.
  */
 export class XrefCompletionProvider implements vscode.CompletionItemProvider {
   constructor(private readonly workspaceState: vscode.Memento) {}
@@ -20,7 +29,9 @@ export class XrefCompletionProvider implements vscode.CompletionItemProvider {
     position: vscode.Position,
   ): Promise<vscode.CompletionItem[]> {
     const context = createContext(document, position)
-    if (shouldProvide(context, 'xref:')) {
+    if (
+      shouldProvideCompletion(context.textFullLine, position.character, 'xref:')
+    ) {
       const antoraDocumentContext = await getAntoraDocumentContext(
         document.uri,
         this.workspaceState,
@@ -29,24 +40,14 @@ export class XrefCompletionProvider implements vscode.CompletionItemProvider {
         return []
       }
       return provideCrossRef(context)
-    } else if (shouldProvide(context, '<<')) {
+    } else if (
+      shouldProvideCompletion(context.textFullLine, position.character, '<<')
+    ) {
       return provideInternalRef(context)
     } else {
       return []
     }
   }
-}
-
-/**
- * Checks if we should provide any CompletionItems
- * @param context
- */
-function shouldProvide(context: Context, keyword: string): boolean {
-  const occurrence = context.textFullLine.indexOf(
-    keyword,
-    context.position.character - keyword.length,
-  )
-  return occurrence === context.position.character - keyword.length
 }
 
 async function getIdsFromFile(file: vscode.Uri) {
@@ -61,42 +62,28 @@ async function getIdsFromFile(file: vscode.Uri) {
 async function provideCrossRef(
   context: Context,
 ): Promise<vscode.CompletionItem[]> {
-  const { textFullLine, position } = context
-
-  let textLine = textFullLine.substring(position.character)
-  textLine = textLine.split(' ')[0]
-  const search = textLine.split('[')[0]
-  const hasBracket = textLine.includes('[')
+  const { textFullLine, position, document } = context
+  const { search, hasBracket } = parseCrossRefQuery(
+    textFullLine,
+    position.character,
+  )
 
   const completionItems: vscode.CompletionItem[] = []
   const workspacesAdocFiles = await findFiles('**/*.adoc')
   for (const adocFile of workspacesAdocFiles) {
     const labels = await getIdsFromFile(adocFile)
     for (const label of labels) {
-      if (!search || label.match(search)) {
-        const labelText = hasBracket ? label : label + '[]'
-        if (adocFile.fsPath === context.document.uri.fsPath) {
-          completionItems.push(
-            new vscode.CompletionItem(
-              labelText,
-              vscode.CompletionItemKind.Reference,
-            ),
-          )
-        } else {
-          const relativePath =
-            path.relative(
-              path.dirname(context.document.uri.fsPath),
-              adocFile.fsPath,
-            ) +
-            '#' +
-            labelText
-          completionItems.push(
-            new vscode.CompletionItem(
-              relativePath,
-              vscode.CompletionItemKind.Reference,
-            ),
-          )
-        }
+      if (matchesCrossRefQuery(label, search)) {
+        const labelText = buildCrossRefLabel(label, hasBracket, {
+          currentFilePath: document.uri.fsPath,
+          targetFilePath: adocFile.fsPath,
+        })
+        completionItems.push(
+          new vscode.CompletionItem(
+            labelText,
+            vscode.CompletionItemKind.Reference,
+          ),
+        )
       }
     }
   }
@@ -108,13 +95,7 @@ async function provideInternalRef(
   context: Context,
 ): Promise<vscode.CompletionItem[]> {
   const { textFullLine, position, document } = context
-  const indexOfNextWhiteSpace = textFullLine.includes(' ', position.character)
-    ? textFullLine.indexOf(' ', position.character)
-    : textFullLine.length
-  const search = textFullLine.substring(
-    textFullLine.lastIndexOf('<', position.character + 1) + 1,
-    indexOfNextWhiteSpace,
-  )
+  const search = parseInternalRefQuery(textFullLine, position.character)
 
   const internalRefLabels = await getIdsFromFile(document.uri)
 

--- a/src/test/unit/xrefCompletion.test.ts
+++ b/src/test/unit/xrefCompletion.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import * as path from 'node:path'
+import { describe, test } from 'node:test'
+import {
+  buildCrossRefLabel,
+  matchesCrossRefQuery,
+  parseCrossRefQuery,
+  parseInternalRefQuery,
+  shouldProvideCompletion,
+} from '../../features/completion/xrefCompletion.js'
+
+describe('shouldProvideCompletion', () => {
+  test('Should detect the keyword ending exactly at the cursor', () => {
+    // `xref:` typed, cursor right after the colon.
+    assert.strictEqual(shouldProvideCompletion('xref:', 5, 'xref:'), true)
+    assert.strictEqual(shouldProvideCompletion('<<', 2, '<<'), true)
+  })
+
+  test('Should not provide when the keyword does not end at the cursor', () => {
+    assert.strictEqual(shouldProvideCompletion('xref:foo', 8, 'xref:'), false)
+    assert.strictEqual(
+      shouldProvideCompletion('hello world here', 10, 'xref:'),
+      false,
+    )
+  })
+})
+
+describe('parseCrossRefQuery', () => {
+  test('Should return an empty search and no bracket right after "xref:"', () => {
+    assert.deepStrictEqual(parseCrossRefQuery('xref:', 5), {
+      search: '',
+      hasBracket: false,
+    })
+  })
+
+  test('Should extract the id fragment typed before the bracket', () => {
+    assert.deepStrictEqual(parseCrossRefQuery('xref:anchor[]', 5), {
+      search: 'anchor',
+      hasBracket: true,
+    })
+  })
+
+  test('Should stop the search at the first whitespace', () => {
+    assert.deepStrictEqual(parseCrossRefQuery('xref:anchor more', 5), {
+      search: 'anchor',
+      hasBracket: false,
+    })
+  })
+})
+
+describe('matchesCrossRefQuery', () => {
+  test('Should match anything when the search is empty', () => {
+    assert.strictEqual(matchesCrossRefQuery('anchor', ''), true)
+  })
+
+  test('Should match when the label contains the search', () => {
+    assert.strictEqual(matchesCrossRefQuery('myAnchor', 'Anchor'), true)
+  })
+
+  test('Should not match when the label does not contain the search', () => {
+    assert.strictEqual(matchesCrossRefQuery('myAnchor', 'other'), false)
+  })
+})
+
+describe('buildCrossRefLabel', () => {
+  const currentFilePath = path.join('docs', 'current.adoc')
+
+  test('Should use the bare id within the same file and append the brackets', () => {
+    assert.strictEqual(
+      buildCrossRefLabel('anchor', false, {
+        currentFilePath,
+        targetFilePath: currentFilePath,
+      }),
+      'anchor[]',
+    )
+  })
+
+  test('Should not append the brackets when they are already typed', () => {
+    assert.strictEqual(
+      buildCrossRefLabel('anchor', true, {
+        currentFilePath,
+        targetFilePath: currentFilePath,
+      }),
+      'anchor',
+    )
+  })
+
+  test('Should prefix the relative path of the target file for other files', () => {
+    const targetFilePath = path.join('docs', 'other.adoc')
+    assert.strictEqual(
+      buildCrossRefLabel('anchor', false, {
+        currentFilePath,
+        targetFilePath,
+      }),
+      'other.adoc#anchor[]',
+    )
+  })
+})
+
+describe('parseInternalRefQuery', () => {
+  test('Should extract the id fragment typed after "<<"', () => {
+    assert.strictEqual(parseInternalRefQuery('<<anchor', 8), 'anchor')
+  })
+
+  test('Should return an empty string right after "<<"', () => {
+    assert.strictEqual(parseInternalRefQuery('<<', 2), '')
+  })
+
+  test('Should stop at the next whitespace', () => {
+    assert.strictEqual(parseInternalRefQuery('<<anchor and more', 2), 'anchor')
+  })
+})


### PR DESCRIPTION
Extract the pure string logic of the xref/`<<` completion provider (keyword detection, cross-ref query parsing, anchor query matching, relative-path label building, internal-ref query parsing) into a `vscode`-free `xrefCompletion` module, mirroring `antoraResourceId`/`xrefIdExtractor`. The provider keeps only the editor wiring (document lookup, file globbing, CompletionItem creation).

Cover the extracted helpers with fast Node `test:unit` tests instead of relying solely on the extension-host suite.
