### PR TITLE
chore: pin @asciidoctor/core to ~4.0 stable release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@antora/content-classifier": "3.1.15",
-        "@asciidoctor/core": "^4.0.0-alpha.1",
+        "@asciidoctor/core": "~4.0",
         "@orcid/bibtex-parse-js": "0.0.25",
         "html-entities": "^2.4.0",
         "js-yaml": "^4.1.0",
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-E3ivaaOkY59Zb4oHoPWxFUqkVrngAR7XQGS1FuP/wJNfQ62xL25mW+9bSPkGgB7qBzcuQKHzI5RN1SLIowLSSw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-VWBs5HwU2vRutHTwxbXJE5icmps93o9z7i2qFxbz9jDS8Ga7rlMFIa7QKMAMpdBlTrFip60serEns5hB12IX6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -660,7 +660,7 @@
   },
   "dependencies": {
     "@antora/content-classifier": "3.1.15",
-    "@asciidoctor/core": "^4.0.0-alpha.1",
+    "@asciidoctor/core": "~4.0",
     "@orcid/bibtex-parse-js": "0.0.25",
     "html-entities": "^2.4.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Move from the alpha range (^4.0.0-alpha.1) to the stable 4.0 release.

