### PR TITLE
feat: re-enable Kroki diagrams with asciidoctor-kroki 1.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@
 * On Antora pages, stop the workspace-wide `xref:` file-path completion (e.g. `../../../../full.adoc#…`) that competed with the Antora resource id completion, leaving the Antora-aware provider as the sole contributor (#434)
 * Complete the anchors of the referenced page after `xref:<page>#` on Antora pages, sourced from the block ids declared in the target page (e.g. `xref:api:auth:page3.adoc#oauth`) (#434)
 * Resolve Antora `xref:` resource ids in the preview so cross-component/cross-module links (and their `#anchor`) navigate to the referenced page instead of producing a broken link (#434)
+* Re-enable Kroki diagrams: upgrade `asciidoctor-kroki` to `1.0.0-beta.1`, which is compatible with Asciidoctor.js 4.0. The new release also drops the `unxhr` dependency in favor of native `fetch`, so `:kroki-fetch-diagram:` now works in VS Code
 
 ### Documentation
 
 * Migrate the README content into the Antora documentation (`docs/`): one page per topic (install, quick start, preview, export as PDF/HTML/DocBook, paste image, snippets, diagram integration, Asciidoctor.js extensions, Asciidoctor config file, VS Code environment, settings, build from source, contributing, get help) wired into the navigation, and slim the README down to an overview that links to the documentation
 * Add an Antora support page documenting how to enable it and the features available (resource id completion, cross-reference anchor completion, go-to-definition, attribute completion, preview), along with the current limitations
+* Remove the obsolete `unxhr` limitation note about `:kroki-fetch-diagram:` from the diagram integration page, since `asciidoctor-kroki` no longer depends on `unxhr`
 
 ### Infrastructure
 

--- a/docs/modules/ROOT/pages/diagram.adoc
+++ b/docs/modules/ROOT/pages/diagram.adoc
@@ -18,9 +18,3 @@ By default, diagram source is sent to {url-kroki} to be rendered.
 If this is a concern, you can run your own Kroki instance and point the extension to it.
 See the {url-asciidoctor-kroki}#using-your-own-kroki[asciidoctor-kroki instructions] for details.
 ====
-
-[IMPORTANT]
-====
-`:kroki-fetch-diagram:` is currently not supported.
-It relies on `unxhr`, which does not work in VS Code (see https://github.com/ggrossetie/unxhr/issues/98[unxhr#98]).
-====

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@antora/content-classifier": "3.1.15",
         "@asciidoctor/core": "~4.0",
         "@orcid/bibtex-parse-js": "0.0.25",
+        "asciidoctor-kroki": "1.0.0-beta.1",
         "html-entities": "^2.4.0",
         "js-yaml": "^4.1.0",
         "os-browserify": "^0.3.0",
@@ -2160,6 +2161,38 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/asciidoctor-kroki": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/asciidoctor-kroki/-/asciidoctor-kroki-1.0.0-beta.1.tgz",
+      "integrity": "sha512-JHNPBOjnLNUWOs9b43SEow2jzWg7h9FST29El9l4nXwOGHCi4kFYt2YFhdd8V4b4QRbyUpuzS1yrlT6u74dG7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "2.2.3",
+        "pako": "2.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@asciidoctor/core": ">=4.0.0 <5.0.0"
+      }
+    },
+    "node_modules/asciidoctor-kroki/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/asciidoctor-opal-runtime": {
       "version": "0.3.4",
@@ -4839,7 +4872,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -662,6 +662,7 @@
     "@antora/content-classifier": "3.1.15",
     "@asciidoctor/core": "~4.0",
     "@orcid/bibtex-parse-js": "0.0.25",
+    "asciidoctor-kroki": "1.0.0-beta.1",
     "html-entities": "^2.4.0",
     "js-yaml": "^4.1.0",
     "os-browserify": "^0.3.0",

--- a/src/features/asciidoctor/asciidoctorExtensions.ts
+++ b/src/features/asciidoctor/asciidoctorExtensions.ts
@@ -1,4 +1,5 @@
 import { Registry } from '@asciidoctor/core'
+import kroki from 'asciidoctor-kroki'
 import * as vscode from 'vscode'
 import { findFiles } from '../../core/findFiles.js'
 import { mermaidJSProcessor } from '../preview/mermaid.js'
@@ -22,11 +23,8 @@ export class AsciidoctorExtensions {
     const enableKroki = vscode.workspace
       .getConfiguration('asciidoc.extensions', null)
       .get('enableKroki')
-    // asciidoctor-kroki is temporarily disabled: not yet compatible with Asciidoctor 4.0
     if (enableKroki) {
-      vscode.window.showWarningMessage(
-        'Kroki diagrams are temporarily disabled because asciidoctor-kroki is not yet compatible with Asciidoctor 4.0.',
-      )
+      kroki.register(registry)
     }
     registry.block('mermaid', mermaidJSProcessor())
     await this.registerExtensionsInWorkspace(registry)


### PR DESCRIPTION
Upgrade asciidoctor-kroki to 1.0.0-beta.1, compatible with Asciidoctor.js 4.0. The new release drops the unxhr dependency in favor of native fetch, so :kroki-fetch-diagram: now works in VS Code.
