### PR TITLE
fix: render Mermaid diagrams with reader.getString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Fix Mermaid diagrams failing to render with "reader.$read is not a function" — replace the removed Opal `reader.$read()` call with the `reader.getString()` JS API, compatible with Asciidoctor.js 4.0
 * Fix web extension: highlight.js (`hljs`) not defined due to missing `cspSource` in the preview `script-src` CSP directive
 * Fix web extension: l10n keys shown as-is instead of translated strings — embed `bundle.l10n.json` at build time as a fallback when VS Code web does not load the bundle
 * Fix web extension: `global is not defined` — replace `global` with `globalThis` for cross-environment compatibility

--- a/src/features/preview/mermaid.ts
+++ b/src/features/preview/mermaid.ts
@@ -1,14 +1,32 @@
+import type {
+  AbstractBlock,
+  Block,
+  BlockProcessorDslInterface,
+  Processor,
+  Reader,
+} from '@asciidoctor/core'
+
+/**
+ * Inside `registry.block(name, function () { … })`, `this` is the block
+ * processor instance. It exposes both the registration DSL (`onContext`,
+ * `process`, …) and the node factory methods (`createPassBlock`, …).
+ */
+type BlockProcessorContext = BlockProcessorDslInterface & Processor
+
 export function mermaidJSProcessor() {
-  return function () {
-    const self = this
-    self.onContext(['listing', 'literal'])
-    self.process((parent, reader, attrs) => {
-      const diagramText = reader.$read()
-      return this.createPassBlock(
-        parent,
-        `<pre class='mermaid'>${diagramText}</pre>`,
-        attrs,
-      )
-    })
+  return function (this: BlockProcessorContext) {
+    this.onContext(['listing', 'literal'])
+    this.process(
+      (
+        parent: AbstractBlock,
+        reader: Reader,
+        attrs: Record<string, unknown>,
+      ): Block =>
+        this.createPassBlock(
+          parent,
+          `<pre class='mermaid'>${reader.getString()}</pre>`,
+          attrs,
+        ),
+    )
   }
 }

--- a/src/test/unit/mermaid.test.ts
+++ b/src/test/unit/mermaid.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { convert, Extensions } from '@asciidoctor/core'
+import { mermaidJSProcessor } from '../../features/preview/mermaid.js'
+
+async function convertWithMermaid(input: string): Promise<string> {
+  const registry = Extensions.create()
+  registry.block('mermaid', mermaidJSProcessor())
+  const output = await convert(input, {
+    extension_registry: registry,
+    safe: 'safe',
+  })
+  return String(output)
+}
+
+describe('mermaidJSProcessor', () => {
+  test('wraps a [mermaid] listing block in a <pre class="mermaid"> element', async () => {
+    const html = await convertWithMermaid(
+      '[mermaid]\n----\ngraph TD\n  A --> B\n----',
+    )
+    assert.match(html, /<pre class='mermaid'>graph TD\n {2}A --> B<\/pre>/)
+  })
+
+  test('handles a [mermaid] literal block (delimited with dots)', async () => {
+    const html = await convertWithMermaid(
+      '[mermaid]\n....\nsequenceDiagram\n  Alice->>Bob: Hi\n....',
+    )
+    assert.match(
+      html,
+      /<pre class='mermaid'>sequenceDiagram\n {2}Alice->>Bob: Hi<\/pre>/,
+    )
+  })
+
+  test('preserves the diagram source verbatim, without HTML-escaping it', async () => {
+    const html = await convertWithMermaid('[mermaid]\n----\nA-->B & C\n----')
+    assert.ok(
+      html.includes("<pre class='mermaid'>A-->B & C</pre>"),
+      `expected raw diagram text, got: ${html}`,
+    )
+  })
+
+  test('does not touch listing blocks that are not mermaid', async () => {
+    const html = await convertWithMermaid('----\nplain listing\n----')
+    assert.doesNotMatch(html, /class='mermaid'/)
+    assert.match(html, /plain listing/)
+  })
+})


### PR DESCRIPTION
The Mermaid block processor called the Opal-style `reader.$read()`, which no longer exists in the Asciidoctor.js 4.0 JS API. Loading any document with a `[mermaid]` block failed with "reader.$read is not a function".

Replace it with the documented `reader.getString()` API, add explicit types to the block processor, and cover it with a unit test.