### PR TITLE
fix: detect antora.yml for partials/examples and across Windows drive-letter case (#957, #958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * Fix the docked table of contents (`toc2`) text color referencing a non-existent `--vscode-editor-color` theme variable, which left the text without an explicit color; use `--vscode-editor-foreground`
 * Fix the `[.text-center]` role not centering a block's caption/title in the preview (e.g. an image caption stayed left-aligned): the default `.imageblock > .title` rule pinned the title to the left, overriding the centering inherited from the role; add a `.text-center > .title` override (#1031)
 * Fix the bundled "Noto Serif" preview font never loading because its `@font-face` rules used `src: local('./fonts/…woff') format('woff')` — `local()` resolves an installed font by name, not a file, and `format()` is invalid after it; load the files with `url()` so the preview uses the bundled Noto Serif instead of falling back to a generic serif
+* Fix `antora.yml` detection failing for AsciiDoc documents that live under `partials/` or `examples/` rather than `pages/` (#958): the detection was hardcoded to `modules/<module>/pages/…`, so partials and examples had no Antora context and their resource ids (images, includes) could not resolve. It now recognizes the `pages`, `partials` and `examples` content families
+* Fix `antora.yml` detection failing on Windows when the workspace scan and the open document disagree on the drive-letter case (e.g. `/e:/…` vs `/E:/…`), which defeated the path prefix comparison and broke features such as image preview (#957)
 
 ### Improvements
 

--- a/src/features/antora/antoraConfigMatcher.ts
+++ b/src/features/antora/antoraConfigMatcher.ts
@@ -1,0 +1,57 @@
+import { posix as posixpath } from 'node:path'
+
+// Antora content families that hold AsciiDoc/text documents a user may open and
+// edit. A document under one of these (i.e. `modules/<module>/<family>/…`)
+// belongs to the Antora component described by the nearest `antora.yml`.
+// Restricting this to `pages` (the historical behaviour) left partials and
+// examples without an Antora context, which broke resource resolution (images,
+// includes, …). See #958.
+const ANTORA_TEXT_FAMILY_PATH_RX = /^\/[^/]+\/(pages|partials|examples)\/.*/
+
+// Matches an upper-case Windows drive letter at the start of a URI path, e.g.
+// the `E` in `/E:/aaa/…`.
+const driveLetterRx = /(?<=^\/)([A-Z])(?=:\/)/
+
+/**
+ * Lower-case a Windows drive letter so paths coming from different VS Code APIs
+ * compare equal. On Windows, `vscode.workspace.findFiles` yields a lower-case
+ * drive letter (`/e:/…`) while the URI of the open document keeps the upper-case
+ * one (`/E:/…`), so a naive `startsWith` against the config path fails. This is
+ * a no-op for POSIX paths (they have no drive letter). See microsoft/vscode#194692
+ * and #957.
+ */
+export function normalizeDriveLetter(path: string): string {
+  return path.replace(driveLetterRx, (driveLetter) => driveLetter.toLowerCase())
+}
+
+/**
+ * Decide which `antora.yml` applies to an AsciiDoc document, working purely from
+ * paths (no VS Code APIs) so the logic can be unit tested outside the extension
+ * host. Returns the matching config path (verbatim, as passed in) or `undefined`
+ * when the document does not live in any Antora module.
+ *
+ * @param asciidocDocumentPath the path of the AsciiDoc document (URI `path`)
+ * @param antoraConfigPaths the paths of the discovered `antora.yml` files
+ */
+export function findApplicableAntoraConfigPath(
+  asciidocDocumentPath: string,
+  antoraConfigPaths: string[],
+): string | undefined {
+  const documentPath = posixpath.normalize(
+    normalizeDriveLetter(asciidocDocumentPath),
+  )
+  for (const antoraConfigPath of antoraConfigPaths) {
+    const configPath = normalizeDriveLetter(antoraConfigPath)
+    const parentDirPath = configPath.slice(0, configPath.lastIndexOf('/'))
+    const modulesDirPath = posixpath.normalize(`${parentDirPath}/modules`)
+    if (
+      documentPath.startsWith(modulesDirPath) &&
+      documentPath
+        .slice(modulesDirPath.length)
+        .match(ANTORA_TEXT_FAMILY_PATH_RX)
+    ) {
+      return antoraConfigPath
+    }
+  }
+  return undefined
+}

--- a/src/features/antora/antoraDocument.ts
+++ b/src/features/antora/antoraDocument.ts
@@ -7,6 +7,7 @@ import { FileType, Memento, Uri } from 'vscode'
 import { dir, exists } from '../../core/file.js'
 import { findFiles } from '../../core/findFiles.js'
 import { getWorkspaceFolder } from '../../core/workspace.js'
+import { findApplicableAntoraConfigPath } from './antoraConfigMatcher.js'
 import {
   AntoraConfig,
   AntoraContext,
@@ -85,32 +86,25 @@ function getAntoraConfigUris(): Promise<Uri[]> {
 export async function findAntoraConfigFile(
   textDocumentUri: Uri,
 ): Promise<Uri | undefined> {
-  const asciidocFilePath = posixpath.normalize(textDocumentUri.path)
   const antoraConfigUris = await getAntoraConfigUris()
-  // check for Antora configuration
-  for (const antoraConfigUri of antoraConfigUris) {
-    const antoraConfigParentDirPath = antoraConfigUri.path.slice(
-      0,
-      antoraConfigUri.path.lastIndexOf('/'),
-    )
-    const modulesDirPath = posixpath.normalize(
-      `${antoraConfigParentDirPath}/modules`,
-    )
-    if (
-      asciidocFilePath.startsWith(modulesDirPath) &&
-      asciidocFilePath.slice(modulesDirPath.length).match(/^\/[^/]+\/pages\/.*/)
-    ) {
-      console.log(
-        `Found an Antora configuration file at ${antoraConfigUri.path} for the AsciiDoc document ${asciidocFilePath}`,
-      )
-      return antoraConfigUri
-    }
-  }
-  const antoraConfigPaths = antoraConfigUris.map((uri) => uri.path)
-  console.log(
-    `Unable to find an applicable Antora configuration file in [${antoraConfigPaths.join(', ')}] for the AsciiDoc document ${asciidocFilePath}`,
+  const matchedConfigPath = findApplicableAntoraConfigPath(
+    textDocumentUri.path,
+    antoraConfigUris.map((uri) => uri.path),
   )
-  return undefined
+  if (matchedConfigPath === undefined) {
+    const antoraConfigPaths = antoraConfigUris.map((uri) => uri.path)
+    console.log(
+      `Unable to find an applicable Antora configuration file in [${antoraConfigPaths.join(', ')}] for the AsciiDoc document ${textDocumentUri.path}`,
+    )
+    return undefined
+  }
+  const matchedConfigUri = antoraConfigUris.find(
+    (uri) => uri.path === matchedConfigPath,
+  )
+  console.log(
+    `Found an Antora configuration file at ${matchedConfigUri.path} for the AsciiDoc document ${textDocumentUri.path}`,
+  )
+  return matchedConfigUri
 }
 
 export async function antoraConfigFileExists(

--- a/src/test/antoraSupport.test.ts
+++ b/src/test/antoraSupport.test.ts
@@ -106,6 +106,35 @@ describe('Antora support with multi-documentation components', () => {
       antoraConfigExpectedPathSegments: apiAntoraPaths,
     })
 
+    const partialPaths = [
+      ...apiDocumentationComponentPaths,
+      'modules',
+      'auth',
+      'partials',
+      'login.adoc',
+    ]
+    await createFile('Reusable login steps', ...partialPaths)
+    testCases.push({
+      title:
+        'Should return Antora config for document inside "partials" directory',
+      asciidocPathSegments: partialPaths,
+      antoraConfigExpectedPathSegments: apiAntoraPaths,
+    })
+    const examplePaths = [
+      ...apiDocumentationComponentPaths,
+      'modules',
+      'auth',
+      'examples',
+      'sample.adoc',
+    ]
+    await createFile('= Example', ...examplePaths)
+    testCases.push({
+      title:
+        'Should return Antora config for document inside "examples" directory',
+      asciidocPathSegments: examplePaths,
+      antoraConfigExpectedPathSegments: apiAntoraPaths,
+    })
+
     const cliDocumentationComponentPaths = ['docs', 'multiComponents', 'cli']
     const cliAntoraPaths = [...cliDocumentationComponentPaths, 'antora.yml']
     await createFile(`name: "cli"\nversion: "2.0"\n`, ...cliAntoraPaths)

--- a/src/test/unit/antoraConfigMatcher.test.ts
+++ b/src/test/unit/antoraConfigMatcher.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  findApplicableAntoraConfigPath,
+  normalizeDriveLetter,
+} from '../../features/antora/antoraConfigMatcher.js'
+
+describe('findApplicableAntoraConfigPath', () => {
+  const configPath = '/docs/antora.yml'
+  const configs = [configPath]
+
+  test('Should match a document under a "pages" directory', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath(
+        '/docs/modules/ROOT/pages/index.adoc',
+        configs,
+      ),
+      configPath,
+    )
+  })
+
+  // #958 — documents under partials used to be left without an Antora context.
+  test('Should match a document under a "partials" directory', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath(
+        '/docs/modules/auth/partials/login.adoc',
+        configs,
+      ),
+      configPath,
+    )
+  })
+
+  test('Should match a document under an "examples" directory', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath(
+        '/docs/modules/auth/examples/sample.adoc',
+        configs,
+      ),
+      configPath,
+    )
+  })
+
+  test('Should match a document nested inside the family directory', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath(
+        '/docs/modules/auth/pages/3rd-party/sso.adoc',
+        configs,
+      ),
+      configPath,
+    )
+  })
+
+  test('Should not match a document outside a content family directory', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath(
+        '/docs/modules/auth/writer-guide.adoc',
+        configs,
+      ),
+      undefined,
+    )
+  })
+
+  test('Should not match a document under a non-text family (e.g. images)', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath(
+        '/docs/modules/ROOT/images/diagram.png',
+        configs,
+      ),
+      undefined,
+    )
+  })
+
+  test('Should not match a document outside any "modules" directory', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath('/docs/contributing.adoc', configs),
+      undefined,
+    )
+  })
+
+  test('Should pick the config whose module tree contains the document', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath('/docs/cli/modules/ROOT/pages/run.adoc', [
+        '/docs/api/antora.yml',
+        '/docs/cli/antora.yml',
+      ]),
+      '/docs/cli/antora.yml',
+    )
+  })
+
+  // #957 — on Windows the config path and the open document differ only by the
+  // case of the drive letter, which used to defeat the prefix comparison.
+  test('Should match despite a Windows drive-letter case mismatch', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath('/E:/aaa/modules/ROOT/pages/index.adoc', [
+        '/e:/aaa/antora.yml',
+      ]),
+      '/e:/aaa/antora.yml',
+    )
+  })
+
+  test('Should return the config path verbatim (not the normalized one)', () => {
+    assert.strictEqual(
+      findApplicableAntoraConfigPath('/E:/aaa/modules/ROOT/pages/index.adoc', [
+        '/E:/aaa/antora.yml',
+      ]),
+      '/E:/aaa/antora.yml',
+    )
+  })
+})
+
+describe('normalizeDriveLetter', () => {
+  test('Should lower-case an upper-case Windows drive letter', () => {
+    assert.strictEqual(
+      normalizeDriveLetter('/E:/aaa/index.adoc'),
+      '/e:/aaa/index.adoc',
+    )
+  })
+
+  test('Should leave a POSIX path untouched', () => {
+    assert.strictEqual(
+      normalizeDriveLetter('/docs/index.adoc'),
+      '/docs/index.adoc',
+    )
+  })
+
+  test('Should only touch the leading drive letter', () => {
+    assert.strictEqual(normalizeDriveLetter('/E:/A:/x.adoc'), '/e:/A:/x.adoc')
+  })
+})


### PR DESCRIPTION
findAntoraConfigFile only recognized documents under modules/<module>/pages/, so AsciiDoc files under partials/ or examples/ were left without an Antora context and their resource ids (images, includes) could not resolve (#958). On Windows it also compared paths whose drive-letter case differed (/e:/ from the workspace scan vs /E:/ from the open document), which defeated the prefix check and broke features such as image preview (#957).

Extract the pure matching/normalization logic into antoraConfigMatcher.ts (findApplicableAntoraConfigPath, normalizeDriveLetter) so it has no vscode dependency and can be unit tested outside the extension host; findAntoraConfigFile now only does the VS Code I/O and delegates. The recognized content families are now pages, partials and examples, and the drive letter is normalized on both sides.

Resolves #957 
Resolves #958