### PR TITLE
Preview diagram & theme improvements (Mermaid ELK/ZenUML, theme attribute, Kroki dark mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Complete the anchors of the referenced page after `xref:<page>#` on Antora pages, sourced from the block ids declared in the target page (e.g. `xref:api:auth:page3.adoc#oauth`) (#434)
 * Resolve Antora `xref:` resource ids in the preview so cross-component/cross-module links (and their `#anchor`) navigate to the referenced page instead of producing a broken link (#434)
 * Re-enable Kroki diagrams: upgrade `asciidoctor-kroki` to `1.0.0-beta.1`, which is compatible with Asciidoctor.js 4.0. The new release also drops the `unxhr` dependency in favor of native `fetch`, so `:kroki-fetch-diagram:` now works in VS Code
+* Extend the bundled Mermaid renderer beyond the core diagrams: register the ELK layout engine (`@mermaid-js/layout-elk`, enabling `layout: elk`) and the ZenUML diagram (`@mermaid-js/mermaid-zenuml`, #947). The preview now disables Mermaid's `startOnLoad` and calls `run()` itself, so these external diagrams are registered before any diagram is detected
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Resolve Antora `xref:` resource ids in the preview so cross-component/cross-module links (and their `#anchor`) navigate to the referenced page instead of producing a broken link (#434)
 * Re-enable Kroki diagrams: upgrade `asciidoctor-kroki` to `1.0.0-beta.1`, which is compatible with Asciidoctor.js 4.0. The new release also drops the `unxhr` dependency in favor of native `fetch`, so `:kroki-fetch-diagram:` now works in VS Code
 * Extend the bundled Mermaid renderer beyond the core diagrams: register the ELK layout engine (`@mermaid-js/layout-elk`, enabling `layout: elk`) and the ZenUML diagram (`@mermaid-js/mermaid-zenuml`, #947). The preview now disables Mermaid's `startOnLoad` and calls `run()` itself, so these external diagrams are registered before any diagram is detected
+* Expose the active VS Code color theme to the preview conversion as a `vscode-theme` document attribute (`dark`/`light`), so documents can branch on it (e.g. `ifeval::["{vscode-theme}" == "dark"]`) and diagram extensions can request a matching theme; the preview re-renders when the color theme changes
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix the bundled "Noto Serif" preview font never loading because its `@font-face` rules used `src: local('./fonts/…woff') format('woff')` — `local()` resolves an installed font by name, not a file, and `format()` is invalid after it; load the files with `url()` so the preview uses the bundled Noto Serif instead of falling back to a generic serif
 * Fix `antora.yml` detection failing for AsciiDoc documents that live under `partials/` or `examples/` rather than `pages/` (#958): the detection was hardcoded to `modules/<module>/pages/…`, so partials and examples had no Antora context and their resource ids (images, includes) could not resolve. It now recognizes the `pages`, `partials` and `examples` content families
 * Fix `antora.yml` detection failing on Windows when the workspace scan and the open document disagree on the drive-letter case (e.g. `/e:/…` vs `/E:/…`), which defeated the path prefix comparison and broke features such as image preview (#957)
+* Fix Kroki diagrams with a transparent background (e.g. TikZ) being invisible in the dark/high-contrast preview themes: give Kroki image blocks a light background card so every diagram stays legible, regardless of whether the backend emits a transparent or opaque-white image
 
 ### Improvements
 

--- a/examples/regression-4.0/_partials/code-with-callouts.rb
+++ b/examples/regression-4.0/_partials/code-with-callouts.rb
@@ -1,0 +1,4 @@
+require 'asciidoctor' # <1>
+
+Asciidoctor.convert_file 'doc.adoc', safe: :safe # <2>
+puts 'done' # <3>

--- a/examples/regression-4.0/_partials/deep.rb
+++ b/examples/regression-4.0/_partials/deep.rb
@@ -1,0 +1,1 @@
+puts 'I am a deeply nested include (fragment.adoc -> deep.rb).'

--- a/examples/regression-4.0/_partials/fragment.adoc
+++ b/examples/regression-4.0/_partials/fragment.adoc
@@ -1,0 +1,8 @@
+This paragraph comes from an included fragment (`_partials/fragment.adoc`).
+
+It also pulls in a nested include below, to exercise include-within-include resolution.
+
+[source,ruby]
+----
+include::deep.rb[]
+----

--- a/examples/regression-4.0/smoke-test.adoc
+++ b/examples/regression-4.0/smoke-test.adoc
@@ -5,6 +5,7 @@ v4.0.0, 2026-06-24: first 4.0 release candidate
 :icons: font
 :stem:
 :source-highlighter: highlight.js
+:highlightjs-languages: dockerfile
 :sectnums:
 :experimental:
 
@@ -188,21 +189,27 @@ fn main() {
 }
 ----
 
-[source,hcl]
+[source,dockerfile]
 ----
-resource "aws_s3_bucket" "b" {
-  bucket = "my-bucket"
-}
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm ci --omit=dev
+CMD ["node", "server.js"]
 ----
 
-// EXPECTED: python and rust are highlighted; hcl/terraform may not be bundled
-// (#969). Note which languages fail to color.
+// EXPECTED: all three blocks are highlighted. python and rust ship in the common
+// Highlight.js bundle, so they color out of the box. `dockerfile` is NOT in the
+// common bundle — it colors only because `:highlightjs-languages: dockerfile`
+// (set in the header) loads the extra grammar on demand (#969). If the
+// dockerfile block renders as plain monochrome text, the on-demand language
+// loading regressed; if python/rust also fail, the base highlighter is broken.
 
 // ############################################################################
 // NETWORK-DEPENDENT: DIAGRAMS (need a reachable Kroki server + Kroki enabled)
 // ############################################################################
 
-== Mermaid — #947 (ZenUML)
+== Mermaid
 
 [mermaid]
 ....
@@ -211,8 +218,45 @@ sequenceDiagram
     Bob-->>Alice: Hi Alice
 ....
 
-// EXPECTED: a rendered sequence diagram (dark-theme aware). Then try a ZenUML
-// diagram if you use one (#947) and confirm it renders rather than erroring.
+// EXPECTED: a rendered sequence diagram (dark-theme aware). Core Mermaid
+// diagrams are rendered client-side by the bundled mermaid.esm.min.mjs (NOT via
+// Kroki — the native [mermaid] processor overrides Kroki's).
+
+=== Mermaid ELK layout
+
+[mermaid]
+....
+---
+config:
+  layout: elk
+---
+flowchart LR
+  A[Start] --> B{Decision}
+  B -->|yes| C[Do thing]
+  B -->|no| D[Skip]
+  C --> E[End]
+  D --> E
+....
+
+// EXPECTED: a flowchart laid out by the ELK engine. The layout loader lives in
+// @mermaid-js/layout-elk, now bundled and registered via registerLayoutLoaders;
+// without it, `layout: elk` silently falls back to the default dagre layout.
+
+=== Mermaid ZenUML
+
+[mermaid]
+....
+zenuml
+    Alice->Bob: "Hello Bob"
+    Bob->Alice: "Hi Alice"
+....
+
+// EXPECTED: a ZenUML sequence diagram. ZenUML is NOT a core Mermaid diagram; it
+// comes from @mermaid-js/mermaid-zenuml, now bundled and registered via
+// registerExternalDiagrams. Without it the block errors with an unknown diagram
+// type (#947). This is the only supported ZenUML path — Kroki has no zenuml
+// backend. KNOWN LIMITATION: ZenUML draws its own opaque white canvas and does
+// not follow mermaid's `theme: dark`, so it stays light in the dark preview.
 
 == PlantUML & Graphviz via Kroki
 
@@ -229,21 +273,61 @@ Bob --> Alice: OK
 digraph G { a -> b -> c; a -> c; }
 ....
 
-// EXPECTED: both diagrams render as images. Offline PlantUML rendering is
-// tracked in #965; clickable links inside PlantUML in the preview in #617.
+// EXPECTED: both diagrams render as <img> from the Kroki server. PlantUML and
+// Graphviz emit an opaque (white) background, so they stay legible on the dark
+// theme as-is. Offline PlantUML rendering is tracked in #965; clickable links
+// inside PlantUML in #617.
+//
+// NOTE: `opts=inline` (true inline <svg>, themeable, no file/server at view
+// time) is intentionally NOT used yet — it needs the next asciidoctor.js +
+// asciidoctor-kroki release (data-URI inline SVG support) bumped here. Re-add
+// `opts=inline` to these blocks once those versions land.
 
 == TikZ via Kroki — #956
 
 [tikz]
 ....
+\documentclass[border=4pt]{standalone}
+\usepackage{tikz}
+\begin{document}
 \begin{tikzpicture}
-  \draw (0,0) circle (1cm);
+  \filldraw[draw=purple, fill=purple!30, line width=1.5pt] (0,0) circle (1cm);
 \end{tikzpicture}
+\end{document}
 ....
 
-// EXPECTED: a rendered circle. If it fails, confirm whether the bundled
-// asciidoctor-kroki version supports tikz (#956).
+// EXPECTED: a purple circle, rendered as <img>. Things to verify:
+//   1. Kroki's TikZ backend needs a complete LaTeX document (\documentclass …
+//      \begin{document} … \end{document}); a bare tikzpicture fails to compile
+//      (#956).
+//   2. TikZ output has a transparent background, so a default black stroke is
+//      invisible in the dark-theme preview. We draw the circle in purple (with a
+//      light purple fill) so it stays legible on both light and dark themes
+//      without depending on a background.
+//
+// NOTE: ZenUML is intentionally NOT tested via Kroki — Kroki has no zenuml
+// backend. The supported path is the native Mermaid ZenUML diagram in the
+// "Mermaid ZenUML" section above (#947).
 
+// ----------------------------------------------------------------------------
+// DARK-THEME DIAGRAM BACKGROUNDS
+// Kroki backends disagree on background: PlantUML and Graphviz render opaque
+// white, while TikZ renders transparent. The preview CSS normalises this by
+// giving Kroki image blocks a light background card in dark/high-contrast
+// themes; the purple TikZ stroke above is a belt-and-braces check that survives
+// even without that card. Once `opts=inline` is re-enabled (next asciidoctor.js
+// + kroki release), the inline <svg> can additionally be restyled for dark mode.
+//
+// MERMAID DIAGRAM SUPPORT (client-side, generateMermaid)
+// Core v11 diagrams work out of the box (flowchart, sequence, class, state, er,
+// gantt, pie, gitGraph, journey, mindmap, timeline, quadrant, requirement, c4,
+// sankey, xychart, block, packet, kanban, radar, treemap; KaTeX math bundled).
+// Bundled add-ons, registered before mermaid.run():
+//   - ELK layout (layout: elk)  -> @mermaid-js/layout-elk     -> registerLayoutLoaders
+//   - ZenUML (zenuml diagram)   -> @mermaid-js/mermaid-zenuml -> registerExternalDiagrams
+// Still NOT bundled (follow-up): architecture-beta icon packs, which need an
+// @iconify-json/<set> registered via registerIconPacks — deferred because each
+// set is multi-MB and architecture-beta is still experimental upstream.
 // ============================================================================
 // END — record any section that did not match its EXPECTED note as a release
 // blocker with the referenced issue number.

--- a/examples/regression-4.0/smoke-test.adoc
+++ b/examples/regression-4.0/smoke-test.adoc
@@ -1,0 +1,250 @@
+= AsciiDoctor 4.0 Preview Regression Smoke Test: A Subtitle
+John Doe <john@example.com>; Jane Roe <jane@example.com>
+v4.0.0, 2026-06-24: first 4.0 release candidate
+:toc: macro
+:icons: font
+:stem:
+:source-highlighter: highlight.js
+:sectnums:
+:experimental:
+
+// ============================================================================
+// HOW TO USE
+// ----------------------------------------------------------------------------
+// Open this file and run "AsciiDoc: Open Preview to the Side".
+// Each section has an "EXPECTED:" note describing what a correct render shows.
+// Anything rendering as `[object Promise]`, a raw macro, a broken link, an
+// empty diagram, or a missing element is a regression from the Asciidoctor.js
+// 4.0 migration. Issue numbers point at the original report.
+//
+// Network note: diagram sections need a reachable Kroki server (and the Kroki
+// integration enabled). They are grouped at the end and clearly marked.
+// ============================================================================
+
+toc::[]
+
+== Document header & TOC
+
+// EXPECTED: the title shows "...Smoke Test" with " A Subtitle" as a smaller
+// subtitle; two authors with clickable mailto links (NOT `[object Promise]`,
+// regression of subMacros being async, #async-header); the revision line shows
+// "v4.0.0, 2026-06-24: first 4.0 release candidate"; the macro TOC above renders
+// as a real list of links (NOT `[object Promise]`, regression of the async
+// `outline` conversion).
+
+This is the body. It should appear below a fully rendered header.
+
+== STEM / Math (MathJax + CSP) — #314
+
+Inline asciimath: stem:[sqrt(4) = 2] and inline latexmath: latexmath:[E = mc^2].
+
+[stem]
+++++
+\sqrt{n!} \approx \sqrt{2 \pi n}\left(\frac{n}{e}\right)^n
+++++
+
+// EXPECTED: both inline expressions and the block equation render as typeset
+// math. If they show as raw `\sqrt{...}` text, MathJax failed to load (often a
+// Content-Security-Policy regression, #314).
+
+== Footnotes — #384, #945
+
+A statement needing a citation.footnote:[A simple footnote.]
+A reused, named footnote.footnote:disclaimer[See the disclaimer below.]
+The same named footnote again.footnote:disclaimer[]
+
+// EXPECTED: a single "footnotes" block at the bottom; the named footnote appears
+// exactly once and is NOT rendered twice (#384); footnote markers link to it.
+
+== Cross references
+
+See <<Document header & TOC>> and the xref:#callouts-via-include[callout section].
+
+[#anchor-target]
+This paragraph is an anchor target.
+
+Jump to <<anchor-target,this custom text>>.
+
+// EXPECTED: all three links are clickable and navigate within the preview; the
+// custom link text "this custom text" is used (xreftext is async in 4.0 —
+// regression would show `[object Promise]` or the raw id).
+
+[#callouts-via-include]
+== Callouts in an included code block — #971, dfcb1b8
+
+[source,ruby]
+----
+include::_partials/code-with-callouts.rb[]
+----
+<1> Require the library.
+<2> Convert a file.
+<3> Print a completion message.
+
+// EXPECTED: the code is syntax-highlighted AND the three callout badges (1,2,3)
+// remain visible on the right of their lines, with a matching colist below
+// (#dfcb1b8 / highlight.js conum merge). No "no callout found for <n>" warning
+// in the editor (false positive, #971).
+
+== Nested includes
+
+include::_partials/fragment.adoc[]
+
+// EXPECTED: the fragment paragraph renders, and the deeply nested `deep.rb`
+// include resolves inside the source block (no "include file not found").
+
+== Tables, including math inside cells — #169
+
+[cols="1,1",options="header"]
+|===
+| Expression | Value
+
+| stem:[x^2 + y^2] | a number
+| stem:[\int_0^1 x\,dx] | stem:[1/2]
+|===
+
+// EXPECTED: the table renders with header shading/zebra striping; the math in
+// the cells is typeset. (Scroll-sync jumpiness around math tables is tracked
+// separately in #169 — here only check the render itself.)
+
+== Admonitions, blocks, quotes (theme-aware)
+
+NOTE: This is a note.
+
+[WARNING]
+====
+A complex warning with a nested
+
+* list
+* of items
+====
+
+.A collapsible block
+[%collapsible]
+====
+Hidden content revealed on click.
+====
+
+[quote,Albert Einstein]
+____
+Everything should be made as simple as possible, but not simpler.
+____
+
+****
+A sidebar block.
+****
+
+// EXPECTED: each admonition uses its theme-aware accent color; the collapsible
+// block toggles; quote and sidebar are styled. Verify in BOTH light and dark
+// VS Code themes.
+
+== Inline formatting & replacements — #940
+
+*bold*, _italic_, `monospace`, ^super^, ~sub~, (C) (R) (TM), -- em dash.
+
+Inline code with    multiple    spaces: `a    b    c`.
+
+Keyboard: kbd:[Ctrl+S]. Button: btn:[OK]. Menu: menu:File[Save As].
+
+// EXPECTED: replacements become ©®™; the em dash renders; the spacing inside
+// the inline code is preserved, NOT collapsed to a single space (#940).
+
+== Lists
+
+. First
+. Second
+.. Nested
+
+* Bullet
+* Bullet
+
+Term:: Definition
+Other term:: Other definition
+
+- [ ] todo
+- [x] done
+
+== Images & roles — #1031
+
+[.text-center]
+.A centered caption
+image::../images/document.svg[Document,120]
+
+// EXPECTED: the image is centered AND its caption "Figure N. A centered caption"
+// is centered too (the `[.text-center]` role applies to the title, #1031).
+// (Path is relative to this file; adjust if you move the document.)
+
+== Source highlighting coverage — #969
+
+[source,python]
+----
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+----
+
+[source,rust]
+----
+fn main() {
+    println!("Hello");
+}
+----
+
+[source,hcl]
+----
+resource "aws_s3_bucket" "b" {
+  bucket = "my-bucket"
+}
+----
+
+// EXPECTED: python and rust are highlighted; hcl/terraform may not be bundled
+// (#969). Note which languages fail to color.
+
+// ############################################################################
+// NETWORK-DEPENDENT: DIAGRAMS (need a reachable Kroki server + Kroki enabled)
+// ############################################################################
+
+== Mermaid — #947 (ZenUML)
+
+[mermaid]
+....
+sequenceDiagram
+    Alice->>Bob: Hello Bob
+    Bob-->>Alice: Hi Alice
+....
+
+// EXPECTED: a rendered sequence diagram (dark-theme aware). Then try a ZenUML
+// diagram if you use one (#947) and confirm it renders rather than erroring.
+
+== PlantUML & Graphviz via Kroki
+
+[plantuml]
+....
+@startuml
+Alice -> Bob: Authenticate
+Bob --> Alice: OK
+@enduml
+....
+
+[graphviz]
+....
+digraph G { a -> b -> c; a -> c; }
+....
+
+// EXPECTED: both diagrams render as images. Offline PlantUML rendering is
+// tracked in #965; clickable links inside PlantUML in the preview in #617.
+
+== TikZ via Kroki — #956
+
+[tikz]
+....
+\begin{tikzpicture}
+  \draw (0,0) circle (1cm);
+\end{tikzpicture}
+....
+
+// EXPECTED: a rendered circle. If it fails, confirm whether the bundled
+// asciidoctor-kroki version supports tikz (#956).
+
+// ============================================================================
+// END — record any section that did not match its EXPECTED note as a release
+// blocker with the referenced issue number.
+// ============================================================================

--- a/media/asciidoctor-default.css
+++ b/media/asciidoctor-default.css
@@ -2207,3 +2207,20 @@ p {
 .vscode-high-contrast .prettyprint {
     background: var(--vscode-editor-background, #000);
 }
+
+/* Kroki renders some diagrams (TikZ, Graphviz, …) with a transparent
+   background, so their dark strokes are invisible in dark/high-contrast themes,
+   while PlantUML renders an opaque white background. Normalise both to a
+   readable light card so every diagram stays legible. */
+.vscode-dark .imageblock.kroki img,
+.vscode-dark .imageblock.kroki object,
+.vscode-dark .imageblock.kroki svg,
+.vscode-dark .image.kroki img,
+.vscode-high-contrast .imageblock.kroki img,
+.vscode-high-contrast .imageblock.kroki object,
+.vscode-high-contrast .imageblock.kroki svg,
+.vscode-high-contrast .image.kroki img {
+    background: #fff;
+    border-radius: 4px;
+    padding: 8px;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "@fontsource/open-sans": "4.5.14",
         "@fontsource/roboto-mono": "4.5.10",
         "@highlightjs/cdn-assets": "~11.11.0",
+        "@mermaid-js/layout-elk": "^0.2.1",
+        "@mermaid-js/mermaid-zenuml": "^0.2.3",
         "@playwright/test": "^1.47.2",
         "@types/lodash.throttle": "~4.1",
         "@types/node": "^24.0.0",
@@ -1041,6 +1043,64 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@fontsource/noto-serif": {
       "version": "4.5.11",
       "resolved": "https://registry.npmjs.org/@fontsource/noto-serif/-/noto-serif-4.5.11.tgz",
@@ -1061,6 +1121,56 @@
       "integrity": "sha512-KrJdmkqz6DszT2wV/bbhXef4r0hV3B0vw2mAqei8A2kRnvq+gcJLmmIeQ94vu9VEXrUQzos5M9lH1TAAXpRphw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@headlessui/react/node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@headlessui/tailwindcss": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.2.tgz",
+      "integrity": "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
     },
     "node_modules/@highlightjs/cdn-assets": {
       "version": "11.11.1",
@@ -1089,6 +1199,36 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1139,6 +1279,87 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.1.tgz",
+      "integrity": "sha512-MX9jwhMyd5zDcFsYcl3duDUkKhjVRUCGEQrdCeNV5hCIR6+3FuDDbRbFmvVbAu15K1+juzsYGG+K8MDvCY1Amg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-zenuml": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-zenuml/-/mermaid-zenuml-0.2.3.tgz",
+      "integrity": "sha512-RGBtgL6fc+5Y2Jm9odOH9HRJ80BP4l6atBYnAK5bBzEowF0PU3UtvZRRcbFxImPGPuLIzqZq31ur8lVO0AoF3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zenuml/core": "^3.47.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^10 || ^11"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-zenuml/node_modules/@zenuml/core": {
+      "version": "3.50.1",
+      "resolved": "https://registry.npmjs.org/@zenuml/core/-/core-3.50.1.tgz",
+      "integrity": "sha512-Q18BXvIfhRuGw0JfO4e+pltG04Phhv2E7n35EWTNSZKKH/HEkyE4Sh7KERb9dqaOfjOdRdKvLG0YekjK3fcDXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "@headlessui/react": "^2.2.9",
+        "@headlessui/tailwindcss": "^0.2.2",
+        "antlr4": "~4.11.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "color-string": "^2.1.4",
+        "dompurify": "^3.3.1",
+        "highlight.js": "^11.10.0",
+        "html-to-image": "^1.11.13",
+        "jotai": "^2.16.1",
+        "marked": "^4.3.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "tailwind-merge": "^3.4.0"
+      },
+      "bin": {
+        "zenuml": "dist/cli/zenuml.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.97"
+      },
+      "peerDependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-zenuml/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/@mermaid-js/parser": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
@@ -1147,6 +1368,283 @@
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1499,6 +1997,47 @@
         "node": ">=18"
       }
     },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@secretlint/config-creator": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
@@ -1725,6 +2264,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -2495,11 +3073,34 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/antlr4": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.11.0.tgz",
+      "integrity": "sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/asciidoctor-kroki": {
       "version": "1.0.0-beta.1",
@@ -2958,6 +3559,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3034,6 +3648,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3073,6 +3697,29 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -4021,6 +4668,13 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "dev": true,
+      "license": "EPL-2.0"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4746,6 +5400,16 @@
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -4779,6 +5443,13 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5249,6 +5920,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.1.tgz",
+      "integrity": "sha512-dnuKfU/GLi8B28RRMjQ3AfoN7kfzP8o41+AX2FmITZqEMY8PHnjABq+VkEooomLwYaGjda+pgy0yFSjaHX/ZPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/joycon": {
@@ -6796,6 +7497,69 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -7061,6 +7825,13 @@
       "engines": {
         "node": ">=11.0.0"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/secretlint": {
       "version": "10.2.2",
@@ -7554,6 +8325,13 @@
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -7593,6 +8371,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tar-fs": {
       "version": "2.1.4",
@@ -8094,6 +8891,16 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -614,7 +614,7 @@
     "copy-fonts:roboto-mono": "cp -r node_modules/@fontsource/roboto-mono/files/roboto-mono-latin-variable-wghtOnly-italic.woff2 media/fonts && cp -r node_modules/@fontsource/roboto-mono/files/roboto-mono-latin-variable-wghtOnly-normal.woff2 media/fonts",
     "copy-font-awesome": "cp -r node_modules/font-awesome/fonts media/font-awesome && cp -r node_modules/font-awesome/css media/font-awesome",
     "copy-mathjax": "cp -r node_modules/mathjax media",
-    "copy-mermaid": "cp -r node_modules/mermaid media",
+    "copy-mermaid": "node tasks/copy-mermaid.mjs",
     "copy-highlightjs": "cp node_modules/@highlightjs/cdn-assets/highlight.min.js media/highlightjs && cp -r node_modules/@highlightjs/cdn-assets/languages media/highlightjs && cp -r node_modules/@highlightjs/cdn-assets/styles media/highlightjs",
     "copy-assets": "npm run copy-fonts:all && npm run copy-font-awesome && npm run copy-mathjax && npm run copy-mermaid && npm run copy-highlightjs",
     "dev": "npm run build",
@@ -640,6 +640,8 @@
     "@fontsource/open-sans": "4.5.14",
     "@fontsource/roboto-mono": "4.5.10",
     "@highlightjs/cdn-assets": "~11.11.0",
+    "@mermaid-js/layout-elk": "^0.2.1",
+    "@mermaid-js/mermaid-zenuml": "^0.2.3",
     "@playwright/test": "^1.47.2",
     "@types/lodash.throttle": "~4.1",
     "@types/node": "^24.0.0",
@@ -656,8 +658,8 @@
     "path-browserify": "1.0.1",
     "semver": "^7.3.7",
     "sinon": "^22.0.0",
-    "typescript": "^5.9.3",
-    "textmate-grammar-test": "^0.7.0"
+    "textmate-grammar-test": "^0.7.0",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@antora/content-classifier": "3.1.15",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,6 +208,15 @@ export async function activate(context: vscode.ExtensionContext) {
   )
 
   context.subscriptions.push(
+    vscode.window.onDidChangeActiveColorTheme(() => {
+      // Re-render so the server-side `vscode-theme` attribute (and anything
+      // derived from it, e.g. Highlight.js) reflects the new theme. Client-side
+      // theming (Mermaid, CSS) already updates live via the webview body class.
+      previewManager.refresh(true)
+    }),
+  )
+
+  context.subscriptions.push(
     vscode.workspace.onDidSaveTextDocument((e) => {
       // when the workspace configuration is updated, the file .vscode/settings.json since we are also listening onDidChangeConfiguration we can safely ignore this event
       if (!e.uri.path.endsWith('.vscode/settings.json')) {

--- a/src/features/asciidoctor/asciidocEngine.ts
+++ b/src/features/asciidoctor/asciidocEngine.ts
@@ -199,10 +199,19 @@ export class AsciidocEngine {
     const documentExtensionName = asciidocTextDocument.extensionName
     const documentFilePath = asciidocTextDocument.filePath
     const templateDirs = this.getTemplateDirs()
+    // Expose the active VS Code color theme as a document attribute so authors
+    // can branch on it (e.g. `ifeval::["{vscode-theme}" == "dark"]`) and so
+    // diagram extensions can request a matching theme. Mirrors the dark/light
+    // detection used by the Highlight.js adapter.
+    const themeKind = vscode.window.activeColorTheme.kind
+    const isDarkTheme =
+      themeKind === vscode.ColorThemeKind.Dark ||
+      themeKind === vscode.ColorThemeKind.HighContrast
     const options: { [key: string]: any } = {
       attributes: {
         ...attributes,
         ...antoraAttributes,
+        'vscode-theme': isDarkTheme ? 'dark' : 'light',
         // The following attributes are "intrinsic attributes" but they are not set when the input is a string
         // like we are doing, in that case it is expected that the attributes are set here for the API:
         // https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes

--- a/src/features/preview/asciidoctorWebViewConverter.ts
+++ b/src/features/preview/asciidoctorWebViewConverter.ts
@@ -423,9 +423,45 @@ ${footnoteItems.join('\n')}
   }
 
   private generateMermaid(webviewResourceProvider, nonce) {
+    const mermaidSrc = webviewResourceProvider.asMediaWebViewSrc(
+      'media',
+      'mermaid',
+      'dist',
+      'mermaid.esm.min.mjs',
+    )
+    const elkLayoutSrc = webviewResourceProvider.asMediaWebViewSrc(
+      'media',
+      '@mermaid-js',
+      'layout-elk',
+      'dist',
+      'mermaid-layout-elk.esm.min.mjs',
+    )
+    const zenumlSrc = webviewResourceProvider.asMediaWebViewSrc(
+      'media',
+      '@mermaid-js',
+      'mermaid-zenuml',
+      'dist',
+      'mermaid-zenuml.esm.min.mjs',
+    )
+    // Core Mermaid diagrams ship in mermaid.esm.min.mjs, but a few render paths
+    // live in separate packages that must be registered before mermaid runs:
+    //   - the ELK layout engine (`layout: elk`) via registerLayoutLoaders
+    //   - the ZenUML diagram (`zenuml`) via registerExternalDiagrams
+    // We disable startOnLoad and call run() ourselves so the registrations are
+    // guaranteed to complete before any diagram is detected and rendered.
     return `<script type="module" nonce="${nonce}">
-    import mermaid from '${webviewResourceProvider.asMediaWebViewSrc('media', 'mermaid', 'dist', 'mermaid.esm.min.mjs')}';
-    mermaid.initialize({startOnLoad:true, theme: document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast') ? 'dark' : 'default'});
+    import mermaid from '${mermaidSrc}';
+    import elkLayouts from '${elkLayoutSrc}';
+    import zenuml from '${zenumlSrc}';
+    const dark = document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast');
+    mermaid.registerLayoutLoaders(elkLayouts);
+    await mermaid.registerExternalDiagrams([zenuml]);
+    mermaid.initialize({startOnLoad: false, theme: dark ? 'dark' : 'default'});
+    try {
+      await mermaid.run();
+    } catch (e) {
+      console.error('Mermaid rendering failed', e);
+    }
   </script>`
   }
 

--- a/tasks/copy-mermaid.mjs
+++ b/tasks/copy-mermaid.mjs
@@ -1,0 +1,43 @@
+// Copy the Mermaid renderer and its external diagram add-ons into media/.
+// Implemented in Node (rather than `cp`/`mkdir -p` shell commands) so it works
+// on Windows, where cmd.exe resolves `mkdir`/`rm` to shell builtins that do not
+// understand the `-p`/`-rf` flags.
+import { cpSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+const nodeModules = join(process.cwd(), 'node_modules')
+const media = join(process.cwd(), 'media')
+
+function copy(src, dest) {
+  rmSync(dest, { recursive: true, force: true })
+  cpSync(src, dest, { recursive: true })
+}
+
+// Full Mermaid bundle (lazy-loads its own diagram chunks).
+copy(join(nodeModules, 'mermaid'), join(media, 'mermaid'))
+
+// External add-ons: ship only the pre-bundled `.esm.min` entry and its chunks
+// (the entry the preview imports), not the unused UMD/source-map variants.
+const addons = [
+  {
+    pkg: '@mermaid-js/layout-elk',
+    entry: 'mermaid-layout-elk.esm.min.mjs',
+    chunks: 'mermaid-layout-elk.esm.min',
+  },
+  {
+    pkg: '@mermaid-js/mermaid-zenuml',
+    entry: 'mermaid-zenuml.esm.min.mjs',
+    chunks: 'mermaid-zenuml.esm.min',
+  },
+]
+
+for (const { pkg, entry, chunks } of addons) {
+  const srcDist = join(nodeModules, pkg, 'dist')
+  const destDist = join(media, pkg, 'dist')
+  rmSync(join(media, pkg), { recursive: true, force: true })
+  mkdirSync(join(destDist, 'chunks'), { recursive: true })
+  cpSync(join(srcDist, entry), join(destDist, entry))
+  cpSync(join(srcDist, 'chunks', chunks), join(destDist, 'chunks', chunks), {
+    recursive: true,
+  })
+}


### PR DESCRIPTION
Improvements to the preview's diagram rendering and theme integration:

- Mermaid ELK + ZenUML (#947): bundle and register @mermaid-js/layout-elk (`layout: elk`) and @mermaid-js/mermaid-zenuml (`zenuml`). The preview now drives `mermaid.run()` itself so the add-ons are registered before any diagram is detected.
- `vscode-theme` attribute: expose the active VS Code theme (`dark`/`light`) as a document attribute so docs can branch on it (`ifeval::["{vscode-theme}" == "dark"]`); the preview re-renders on theme change.
- Kroki dark mode: give Kroki image blocks a light background card so transparent diagrams (e.g. TikZ) stay legible in dark/high-contrast themes.
- Smoke test: add ELK/ZenUML sections, swap `hcl` -> `dockerfile` to exercise on-demand Highlight.js grammar loading (#969), and fix the TikZ sample (#956).

CHANGELOG updated. Generated `media/` assets are produced by `copy-mermaid` at build time (not committed).


Resolves #956
Resolves #969
Resolves #947