### PR TITLE
test: run the extension-host suite on a single file via --file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * Add `ide-external-custom-properties.css`, a non-bundled stub declaring the custom properties injected at runtime (`--vscode-*` from the webview theme, `--asciidoc-*` from the extension), so IDEs resolve `var(--…)` references in the preview stylesheets while still flagging typos in our own variables
 * Lint the preview stylesheets with Biome (CSS) and drop browser hacks that are dead weight in the Chromium-based webview: remove the `-moz-`/`-ms-`/`-o-` vendor prefixes and the redundant `-webkit-` ones that already have a standard equivalent (`border-radius`, `box-shadow`, `appearance`, old flexbox, `box-sizing`), along with the IE `*zoom` hasLayout hacks, while keeping the webkit-only properties that still apply (`-webkit-font-smoothing`, `-webkit-tap-highlight-color`, `-webkit-text-size-adjust`, `::-webkit-details-marker`)
 * Publish the extension to the [Open VSX Registry](https://open-vsx.org) during release (in addition to the VS Code Marketplace), making it installable from VSCodium, Cursor, Gitpod, code-server and other VS Code-compatible editors: the release publishes the same `.vsix` via `ovsx`, gated on an `OVSX_TOKEN` secret so it is skipped (without failing the release) until the token is configured (#285)
+* Allow running the extension-host test suite on a single file with `node ./src/test/runTest.mjs --file <substring>` (alias `-f`), instead of always running every `*.test.ts`
 
 ## 3.4.5  (2025-09-16)
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -53,6 +53,12 @@ In that case, you must close your Visual Studio code instance otherwise you will
  Running extension tests from the command line is currently only supported if no other instance of Code is running.
 ====
 
+To run only the tests of a single file (matching by file name), invoke the runner directly with `--file` (alias `-f`):
+
+ $ node ./src/test/runTest.mjs --file foldingProvider
+
+The value is a case-insensitive substring matched against the test file name (the `.test.ts` suffix is optional), so `-f folding` or `-f antora` work too; `antora` would run every `antora*.test.ts` file.
+
 === Running the Web version
 
 To test the extension, run the following command within the repository folder from the command line:

--- a/src/test/runTest.mjs
+++ b/src/test/runTest.mjs
@@ -4,6 +4,31 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+/**
+ * Parse the optional file filter into the environment passed to the VS Code
+ * test host, where it is read back and applied in src/test/suite/index.ts.
+ *
+ *   --file, -f <substring>   only run test files whose name contains <substring>
+ *
+ * Also accepts the `--file=value` form. Examples:
+ *   node ./src/test/runTest.mjs --file preview
+ *   node ./src/test/runTest.mjs -f preview
+ */
+function parseFilters(argv) {
+  const env = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    const eq = arg.indexOf('=')
+    const name = eq === -1 ? arg : arg.slice(0, eq)
+    // Value is either after `=` or the next argument.
+    const value = eq === -1 ? argv[++i] : arg.slice(eq + 1)
+    if (name === '--file' || name === '-f') {
+      env.ASCIIDOC_TEST_FILE = value
+    }
+  }
+  return env
+}
+
 async function main() {
   try {
     const projectRootPath = path.join(__dirname, '..', '..')
@@ -26,6 +51,7 @@ async function main() {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [testsWorkspaceDirectoryPath],
+      extensionTestsEnv: parseFilters(process.argv.slice(2)),
     })
   } catch (_err) {
     process.exit(1)

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -15,10 +15,32 @@ export async function run(): Promise<void> {
   await extension?.activate()
   setExtensionContext((globalThis as any).testExtensionContext)
 
+  // Optional file filter, set from the command line via runTest.mjs:
+  // ASCIIDOC_TEST_FILE only runs test files whose name contains this string
+  // (the `.test.ts`/`.test.js`/`.ts`/`.js` suffix is ignored), e.g. "preview".
+  const fileFilter = process.env.ASCIIDOC_TEST_FILE?.trim()
+
+  const normalize = (name: string) =>
+    name.replace(/\.test\.[jt]s$/, '').replace(/\.[jt]s$/, '')
+
   const testDir = path.join(__dirname, '..')
   const testFiles = readdirSync(testDir)
     .filter((f) => f.endsWith('.test.js'))
+    .filter(
+      (f) =>
+        !fileFilter ||
+        normalize(f)
+          .toLowerCase()
+          .includes(normalize(fileFilter).toLowerCase()),
+    )
     .map((f) => path.join(testDir, f))
+
+  if (testFiles.length === 0) {
+    console.error(
+      `No test file matches ASCIIDOC_TEST_FILE="${fileFilter}" in ${testDir}`,
+    )
+    process.exit(1)
+  }
 
   const controller = new AbortController()
   const stream = nodeTestRun({


### PR DESCRIPTION
Add a --file/-f filter (also --file=value) to src/test/runTest.mjs, forwarded to the extension host through extensionTestsEnv as ASCIIDOC_TEST_FILE and applied in src/test/suite/index.ts before nodeTestRun(). The value is a case-insensitive substring matched against the test file name (extension suffix ignored); no match exits with an error.

Test-name filtering (--test-name-pattern) is intentionally not added: node's run() testNamePatterns option is ignored under isolation: 'none' (mandatory in the extension host) and VS Code strips NODE_OPTIONS, so node's native flag can't be reached.
