### PR TITLE
fix(preview): embed images as data-uri when :data-uri: is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Fix `:data-uri:` not embedding images in the preview (desktop and VS Code for the Web): Asciidoctor's built-in `data-uri` embedding reads from disk, which does not work for VS Code workspaces, so it was disabled. When `:data-uri:` is set the preview now embeds images itself — reading local files (honouring `imagesdir`) through `vscode.workspace.fs` and fetching remote images over HTTP — so both local and remote images (including SVG) are inlined as `data:` URIs
 * Fix paste image (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>V</kbd>) saving to a bogus folder and breaking the inserted macro when a `:imagesdir:` line merely appears inside a delimited block (e.g. a listing block) (#879). The `imagesdir` resolution used a naive text scan that matched those literal lines; it now skips delimited blocks while still honouring an `:imagesdir:` redefined in the document body (so the value reflects where the image is pasted), and falls back to Asciidoctor when the attribute is set outside the document text (e.g. `.asciidoctorconfig`)
 
 * Fix the MathJax 4 preview leaving a stray `$` on each side of every formula: Asciidoctor wraps AsciiMath in `\$…\$` delimiters, but MathJax 4 turns `tex.processEscapes` on by default, which rewrites each `\$` into a literal `<span>$</span>` before AsciiMath runs and steals the delimiters. `processEscapes` is now disabled so the `\$` delimiters reach the AsciiMath input jax intact

--- a/src/features/asciidoctor/asciidocEngine.ts
+++ b/src/features/asciidoctor/asciidocEngine.ts
@@ -223,6 +223,10 @@ export class AsciidocEngine {
     }
     const krokiServerUrl =
       document.getAttribute('kroki-server-url') || 'https://kroki.io'
+    // Detected from the header-only parse: the preview embeds images itself when
+    // `data-uri` is set (see the converter), because Asciidoctor's own data-uri
+    // embedding reads from disk and does not work for VS Code workspaces.
+    const dataUriEnabled = document.isAttribute('data-uri')
 
     // Antora Resource Identifiers resolution
     const antoraDocumentContext = await getAntoraDocumentContext(
@@ -244,6 +248,7 @@ export class AsciidocEngine {
       line,
       null,
       krokiServerUrl,
+      dataUriEnabled,
     )
     ConverterFactory.register(asciidoctorWebViewConverter, 'webview-html5')
 
@@ -317,7 +322,15 @@ export class AsciidocEngine {
         ...(documentBasename && { docname: documentBasename }),
         docfilesuffix: documentExtensionName,
         filetype: asciidoctorWebViewConverter.outfilesuffix.substring(1), // remove the leading '.'
-        '!data-uri': '', // disable data-uri since Asciidoctor.js is unable to read files from a VS Code workspace.
+        // Disable Asciidoctor's own data-uri embedding; the WebView converter
+        // does it instead (see AsciidoctorWebViewConverter, gated on
+        // `dataUriEnabled`). Asciidoctor.js 4.0 dropped Opal and reads via
+        // `node:fs`/`fetch`, so the native path works on the desktop — but not
+        // in VS Code for the Web (no `node:fs`) nor on virtual file systems
+        // (Remote SSH, dev containers, `vscode-vfs:`), where only
+        // `vscode.workspace.fs` can read the file. Embedding through the VS Code
+        // FS API covers every host uniformly.
+        '!data-uri': '',
       },
       backend: 'webview-html5',
       extension_registry: registry,

--- a/src/features/preview/asciidoctorWebViewConverter.ts
+++ b/src/features/preview/asciidoctorWebViewConverter.ts
@@ -19,6 +19,41 @@ import { AsciidocPreviewConfiguration } from './previewConfig.js'
 const BAD_PROTO_RE = /^(vbscript|javascript|data):/i
 const GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/i
 
+const IMAGE_MIME_TYPES: { [ext: string]: string } = {
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+}
+
+function mimeTypeForTarget(target: string): string {
+  const ext = target.split('?')[0].split('#')[0].split('.').pop()?.toLowerCase()
+  return IMAGE_MIME_TYPES[ext] ?? 'application/octet-stream'
+}
+
+/**
+ * Base64-encode raw bytes in a way that works in both the Node desktop
+ * extension host (`Buffer`) and the browser extension host (`btoa`).
+ */
+function encodeBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64')
+  }
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(
+      null,
+      bytes.subarray(i, i + chunkSize) as unknown as number[],
+    )
+  }
+  return btoa(binary)
+}
+
 /**
  * Disallow blacklisted URL types following MarkdownIt and the VS Code Markdown extension
  * @param   {String}  href   The link address
@@ -151,6 +186,7 @@ export class AsciidoctorWebViewConverter {
     line: number | undefined = undefined,
     state?: any,
     private readonly krokiServerUrl?: string,
+    private readonly dataUriEnabled: boolean = false,
   ) {
     const textDocumentUri = textDocument.uri
     this.basebackend = 'html'
@@ -342,9 +378,80 @@ export class AsciidoctorWebViewConverter {
         const alt = resourceUri.split('/').pop().split('.').shift()
         node.setAttribute('target', resourceUri)
         node.setAttribute('alt', alt)
+      } else if (this.dataUriEnabled) {
+        // We embed images ourselves rather than relying on Asciidoctor's own
+        // `data-uri` (disabled in the engine, see asciidocEngine.ts). Since
+        // Asciidoctor.js 4.0 dropped Opal, the native path reads via
+        // `node:fs`/`fetch` and would work on the desktop — but not in VS Code
+        // for the Web (no `node:fs`) nor on virtual file systems (Remote SSH,
+        // dev containers, `vscode-vfs:`), where only `vscode.workspace.fs` can
+        // read the file. Going through the VS Code FS API (local) and `fetch`
+        // (remote) embeds images uniformly across every host.
+        const dataUri = await this.toImageDataUri(node, target)
+        if (dataUri !== undefined) {
+          node.setAttribute('target', dataUri)
+        }
       }
     }
     return await this.baseConverter.convert(node, transform)
+  }
+
+  /**
+   * Build a `data:` URI for an image target, mirroring Asciidoctor's `data-uri`
+   * attribute. Returns undefined when the image cannot be read so the base
+   * converter falls back to rendering the original (linked) target.
+   */
+  private async toImageDataUri(
+    node,
+    target: string,
+  ): Promise<string | undefined> {
+    if (typeof target !== 'string' || target.startsWith('data:')) {
+      return undefined
+    }
+    try {
+      let bytes: Uint8Array
+      let mimeType: string
+      if (/^https?:\/\//i.test(target)) {
+        const response = await fetch(target)
+        if (!response.ok) {
+          return undefined
+        }
+        bytes = new Uint8Array(await response.arrayBuffer())
+        mimeType =
+          response.headers.get('content-type')?.split(';')[0].trim() ||
+          mimeTypeForTarget(target)
+      } else {
+        const fileUri = this.resolveImageUri(node, target)
+        bytes = await vscode.workspace.fs.readFile(fileUri)
+        mimeType = mimeTypeForTarget(target)
+      }
+      return `data:${mimeType};base64,${encodeBase64(bytes)}`
+    } catch (e) {
+      logger.warn(`Unable to embed image "${target}" as data-uri: ${e}`)
+      return undefined
+    }
+  }
+
+  /**
+   * Resolve a local image target to a filesystem URI, honouring `imagesdir` and
+   * resolving relative paths against the AsciiDoc document's directory.
+   *
+   * `imagesdir` is read from the image *node*, not the document: Asciidoctor
+   * captures the value in effect at each image's position during parsing, so
+   * this stays correct when `:imagesdir:` is redefined in the document body
+   * (`document.getAttribute('imagesdir')` would only report the header value).
+   */
+  private resolveImageUri(node, target: string): vscode.Uri {
+    if (target.startsWith('/') || /^[a-z]:[\\/]/i.test(target)) {
+      return vscode.Uri.file(target)
+    }
+    const imagesdir = node.getAttribute('imagesdir', '') || ''
+    const relativePath = imagesdir ? `${imagesdir}/${target}` : target
+    const segments = relativePath.split('/').filter((s) => s.length > 0)
+    return vscode.Uri.joinPath(
+      uri.Utils.dirname(this.textDocument.uri),
+      ...segments,
+    )
   }
 
   /**

--- a/src/test/asciidoctorWebViewConverter.test.ts
+++ b/src/test/asciidoctorWebViewConverter.test.ts
@@ -457,6 +457,58 @@ See xref:my-table[xrefstyle=short] for more reference.
     },
   ]
 
+  async function convertWithDataUri(input: string): Promise<string> {
+    const file = await vscode.workspace.openTextDocument(
+      vscode.Uri.joinPath(workspaceUri, 'asciidoctorWebViewConverterTest.adoc'),
+    )
+    const converter = new AsciidoctorWebViewConverter(
+      file,
+      new TestWebviewResourceProvider(),
+      2,
+      false,
+      new TestAsciidocContributions(),
+      new AsciidocPreviewConfigurationManager().loadAndCacheConfiguration(
+        file.uri,
+      ),
+      undefined,
+      undefined,
+      null,
+      undefined,
+      true, // dataUriEnabled
+    )
+    return (await asciidoctorConvert(
+      input,
+      createConverterOptions(converter, file.fileName),
+    )) as unknown as string
+  }
+
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>'
+  const svgDataUri = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`
+
+  test('Should embed a local SVG as a data-uri when data-uri is enabled', async () => {
+    createdFiles.push(await createFile(svg, 'data-uri-local.svg'))
+    const html = await convertWithDataUri('image::data-uri-local.svg[]')
+    assert.ok(
+      html.includes(`<img src="${svgDataUri}"`),
+      `expected embedded data-uri in:\n${html}`,
+    )
+  })
+
+  test('Should resolve the image against the imagesdir in effect at the image', async () => {
+    createdFiles.push(await createDirectory('data-uri-assets'))
+    createdFiles.push(await createFile(svg, 'data-uri-assets', 'in-dir.svg'))
+    // `:imagesdir:` is read from the image node (position-aware), so the file is
+    // resolved under data-uri-assets/ even though it is set in the document body.
+    const html = await convertWithDataUri(
+      ':imagesdir: data-uri-assets\n\nimage::in-dir.svg[]',
+    )
+    assert.ok(
+      html.includes(`<img src="${svgDataUri}"`),
+      `expected imagesdir-resolved data-uri in:\n${html}`,
+    )
+  })
+
   for (const testCase of testCases) {
     if (testCase.standalone) {
       test(testCase.title, async () =>


### PR DESCRIPTION
Asciidoctor's own data-uri embedding was disabled because it reads from disk. Since 4.0 dropped Opal it reads via node:fs/fetch (so the native path works on the desktop), but not in VS Code for the Web (no node:fs) nor on virtual file systems (Remote SSH, dev containers, vscode-vfs:), where only vscode.workspace.fs can read the file.

When :data-uri: is set, the WebView converter now embeds images itself: local files through vscode.workspace.fs (honouring the position-aware imagesdir read from the image node) and remote ones over HTTP, encoding to base64 in a way that works on both the Node and browser hosts. A failed read falls back to the normal rendering.

Resolves #507 