### PR TITLE
docs: explain using the extension with non-.adoc file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 * Clarify the `asciidoctor-emoji` example on the Asciidoctor.js extensions page: name the extension file and document that emojis are images served from the Twemoji CDN (an internet connection is required), which the preview's Content Security Policy allows over HTTPS by default — so no security setting needs to be changed
 * Add a "Contribute Asciidoctor.js extensions from another VS Code extension" page documenting the `asciidoc.asciidoctorExtensions` contribution point and the `registerAsciidoctorExtensions(registry, context)` hook used to register Asciidoctor.js extensions from a companion VS Code extension
 * Mark "Paste image" as supported in VS Code for the Web in the support matrix: the document paste edit provider is registered unconditionally, so copying an image and pasting it with <kbd>Ctrl</kbd>+<kbd>V</kbd> in the editor works in the browser
+* Add a "File extensions and associations" page documenting the recognized extensions (`.adoc`, `.ad`, `.asciidoc`, `.asc`), how to use the extension with other extensions such as `.txt` via the `files.associations` setting, and why this is discouraged — a few features (workspace symbols, cross-file cross-reference completion, extension-less link resolution) look files up by the `.adoc` extension rather than by language, so they silently ignore non-`.adoc` files (#376)
 
 ### Infrastructure
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,7 @@
 * xref:index.adoc[]
 * xref:quick-start.adoc[]
 * xref:install.adoc[]
+* xref:file-associations.adoc[]
 * Features
 ** xref:edit.adoc[]
 ** xref:preview.adoc[]

--- a/docs/modules/ROOT/pages/file-associations.adoc
+++ b/docs/modules/ROOT/pages/file-associations.adoc
@@ -57,7 +57,7 @@ Cross-file cross-reference completion::
 `xref:` and `<<` completion gathers candidates from `**/*.adoc` files across the workspace. References declared in a `.txt` file are not offered, and a `.txt` file will not contribute its anchors to other documents.
 
 Link resolution without an extension::
-When you kbd:[Ctrl]/kbd:[Cmd]+click a link or `include::`/`xref:` target written without an extension (for example `xref:chapter[]`), the extension resolves it by appending `.adoc`. A bare target that actually points at a `.txt` file will not resolve — you must spell out the full file name.
+When you kbd:[Ctrl]/kbd:[Cmd]+click a link or `include::`/`xref:` target written without an extension (for example `\xref:chapter[]`), the extension resolves it by appending `.adoc`. A bare target that actually points at a `.txt` file will not resolve — you must spell out the full file name.
 
 [CAUTION]
 ====

--- a/docs/modules/ROOT/pages/file-associations.adoc
+++ b/docs/modules/ROOT/pages/file-associations.adoc
@@ -1,0 +1,66 @@
+= File extensions and associations
+:description: Which file extensions the extension recognizes, and how (and why not) to use it with other extensions such as .txt.
+
+The extension activates on files that VS Code identifies as the *AsciiDoc language*.
+Out of the box, the following extensions are registered to that language:
+
+* `.adoc`
+* `.ad`
+* `.asciidoc`
+* `.asc`
+
+[TIP]
+====
+Prefer `.adoc`.
+It is the conventional AsciiDoc file extension, it is the one registered as the AsciiDoc media type, and it is the only extension that every feature of this extension supports without surprises (see <<limitations>>).
+====
+
+[#use-another-extension]
+== Using the extension with another file extension
+
+If your project stores AsciiDoc content under a different extension (for example `.txt`), you can tell VS Code to treat those files as AsciiDoc with the built-in https://code.visualstudio.com/docs/languages/identifiers[`files.associations`] setting.
+
+Add this to your workspace or user `settings.json`:
+
+[,json]
+----
+{
+  "files.associations": {
+    "*.txt": "asciidoc"
+  }
+}
+----
+
+You can also set the association per file from the status bar: open the file, click the language indicator in the bottom-right corner, choose _Configure File Association for '.txt'..._, and pick *AsciiDoc*.
+
+Once a file is associated with the AsciiDoc language, most of the extension comes along, because these features key off the *language*, not the file name:
+
+* Syntax highlighting
+* xref:preview.adoc[Live preview] (and sync scrolling)
+* xref:edit.adoc[Document outline and symbols] for the open file
+* Completion (attributes, includes, cross-references within the file…)
+* Diagnostics
+* xref:snippets.adoc[Snippets] and xref:paste-image.adoc[image pasting]
+* The _Open Preview_, _Export as PDF_, _Save as HTML_… commands and menu entries
+
+[#limitations]
+== Limitations
+
+WARNING: Associating non-`.adoc` files with AsciiDoc is *not* fully equivalent to using `.adoc`. A handful of features look up files by the `.adoc` extension on disk rather than by language, so they will silently ignore your other files.
+
+The features that rely on the `.adoc` extension are:
+
+Workspace-wide symbols::
+The _Go to Symbol in Workspace_ command (kbd:[Ctrl+T]) only indexes `**/*.adoc` files. Symbols defined in a `.txt` file are not discovered, and edits to such files are not watched.
+
+Cross-file cross-reference completion::
+`xref:` and `<<` completion gathers candidates from `**/*.adoc` files across the workspace. References declared in a `.txt` file are not offered, and a `.txt` file will not contribute its anchors to other documents.
+
+Link resolution without an extension::
+When you kbd:[Ctrl]/kbd:[Cmd]+click a link or `include::`/`xref:` target written without an extension (for example `xref:chapter[]`), the extension resolves it by appending `.adoc`. A bare target that actually points at a `.txt` file will not resolve — you must spell out the full file name.
+
+[CAUTION]
+====
+Because of these gaps, using a non-`.adoc` extension is discouraged.
+If you can, rename your files to `.adoc`: it is the official AsciiDoc extension, it keeps every feature working, and your documents will be recognized as AsciiDoc by other tools and platforms (GitHub, GitLab, the Asciidoctor toolchain…) without extra configuration.
+====


### PR DESCRIPTION
Document the recognized AsciiDoc extensions, how to associate other extensions (e.g. .txt) via files.associations, and why this is discouraged: workspace symbols, cross-file xref completion and extension-less link resolution look files up by the .adoc extension rather than by language, so they silently ignore non-.adoc files (#376).

Resolves #376 