### PR TITLE
refactor(links): drop the last hardcoded vscode-resource: URI

### DIFF
--- a/src/features/documentLinkProvider.ts
+++ b/src/features/documentLinkProvider.ts
@@ -31,9 +31,13 @@ function normalizeLink(
     return externalSchemeUri
   }
 
-  // Assume it must be a relative or absolute file path
-  // Use a fake scheme to avoid parse warnings
-  const tempUri = vscode.Uri.parse(`vscode-resource:${link}`)
+  // Assume it must be a relative or absolute file path. We only parse `link` to
+  // split it into a path and a fragment; the resulting URI is never used as a
+  // webview resource. A neutral, non-special scheme is prepended to avoid the
+  // "scheme is missing" parse warning while keeping the path verbatim — `file`,
+  // `http` and `https` must NOT be used here as they make `Uri.parse` prepend a
+  // leading slash to relative paths (and turn an empty path into `/`).
+  const tempUri = vscode.Uri.parse(`adoc-link:${link}`)
 
   let resourcePath
   if (!tempUri.path) {


### PR DESCRIPTION
The preview already loads every resource through Webview.asWebviewUri and builds its CSP from Webview.cspSource, so the only literal vscode-resource: left was the parse trick in the document link provider. That URI is never used as a webview resource — it only splits a link into a path and a fragment — so swap it for a neutral adoc-link: scheme and document why file/http/https must not be used here (Uri.parse would prepend a slash to relative paths).

Closes #317