### PR TITLE
docs: explain skipping front matter in the preview (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix Windows path generation by using `fsPath` (#998) - thanks @anoymouserver
 * Fix TextMate grammar: support dots as delimiter in listing paragraph (#1004)
 * Only provide attribute reference completion when typing inside `{ ... }`, instead of on every word, to reduce noise (notably inside macro targets such as `image::`)
+* Stop offering `:skip-front-matter:` and `:front-matter:` in the `:` document-attribute completion: both are set via the API/CLI (or populated by the processor) and have no effect when declared in the document, so suggesting them as something to set was misleading. They remain referenceable through `{ ... }` completion when present in the parsed document
 * Fix the docked table of contents (`toc2`) text color referencing a non-existent `--vscode-editor-color` theme variable, which left the text without an explicit color; use `--vscode-editor-foreground`
 * Fix the `[.text-center]` role not centering a block's caption/title in the preview (e.g. an image caption stayed left-aligned): the default `.imageblock > .title` rule pinned the title to the left, overriding the centering inherited from the role; add a `.text-center > .title` override (#1031)
 * Fix the bundled "Noto Serif" preview font never loading because its `@font-face` rules used `src: local('./fonts/…woff') format('woff')` — `local()` resolves an installed font by name, not a file, and `format()` is invalid after it; load the files with `url()` so the preview uses the bundled Noto Serif instead of falling back to a generic serif
@@ -81,6 +82,7 @@
 * Add a "Contribute Asciidoctor.js extensions from another VS Code extension" page documenting the `asciidoc.asciidoctorExtensions` contribution point and the `registerAsciidoctorExtensions(registry, context)` hook used to register Asciidoctor.js extensions from a companion VS Code extension
 * Mark "Paste image" as supported in VS Code for the Web in the support matrix: the document paste edit provider is registered unconditionally, so copying an image and pasting it with <kbd>Ctrl</kbd>+<kbd>V</kbd> in the editor works in the browser
 * Add a "File extensions and associations" page documenting the recognized extensions (`.adoc`, `.ad`, `.asciidoc`, `.asc`), how to use the extension with other extensions such as `.txt` via the `files.associations` setting, and why this is discouraged — a few features (workspace symbols, cross-file cross-reference completion, extension-less link resolution) look files up by the `.adoc` extension rather than by language, so they silently ignore non-`.adoc` files (#376)
+* Document how to keep static-site front matter (the `---`/`+++` metadata block at the top of a file) out of the preview by setting the `skip-front-matter` attribute through `asciidoc.preview.asciidoctorAttributes`, and why it must be set there rather than in the document header or `.asciidoctorconfig` (#104)
 
 ### Infrastructure
 

--- a/docs/modules/ROOT/pages/preview.adoc
+++ b/docs/modules/ROOT/pages/preview.adoc
@@ -17,6 +17,40 @@ You can also force a refresh with the *AsciiDoc: Refresh Preview* command.
 
 Set AsciiDoc attributes used to render the preview through the `asciidoc.preview.asciidoctorAttributes` setting.
 
+== Front matter
+
+Files written for static-site generators (Jekyll, Hugo, …) often start with a metadata block delimited by `+++` (TOML) or `---` (YAML):
+
+[source,asciidoc]
+----
+---
+title: cool example
+layout: post
+---
+= My Document
+
+body content
+----
+
+By default, Asciidoctor does not treat this block as metadata, so the preview renders it as a stray horizontal rule followed by a paragraph of `key: value` lines.
+
+To strip the front matter from the preview, set the `skip-front-matter` attribute through the `asciidoc.preview.asciidoctorAttributes` setting:
+
+[source,json]
+----
+"asciidoc.preview.asciidoctorAttributes": {
+  "skip-front-matter": ""
+}
+----
+
+The front matter is then consumed and exposed as the `front-matter` attribute, exactly as with the Asciidoctor `--attribute skip-front-matter` command-line option.
+
+[NOTE]
+====
+The attribute must be set through the setting, not in the document header or an xref:asciidoctorconfig.adoc[`.asciidoctorconfig`] file.
+Front matter is detected at the very top of the file, before the document header and before either of those sources is applied, so a `:skip-front-matter:` declared there is read too late to have any effect.
+====
+
 == Source code highlighting
 
 Source blocks are highlighted out of the box using the bundled https://highlightjs.org[Highlight.js] highlighter -- you don't need to set `:source-highlighter:` for the preview.

--- a/src/features/completion/builtinDocumentAttribute.json
+++ b/src/features/completion/builtinDocumentAttribute.json
@@ -79,11 +79,6 @@
     "insertText": "reproducible:",
     "description": "Prevents last-updated date from being added to HTML footer or DocBook info element. Useful for storing the output in a source code control system as it prevents spurious changes every time you convert the document."
   },
-  "skip-front-matter": {
-    "label": ":skip-front-matter:",
-    "insertText": "skip-front-matter:",
-    "description": "Consume YAML-style frontmatter at top of document and store it in front-matter attribute."
-  },
   "appendix-caption": {
     "label": ":appendix-caption:",
     "insertText": "appendix-caption: ${1:any}",
@@ -293,11 +288,6 @@
     "label": ":firstname:",
     "insertText": "firstname: ${1:any}",
     "description": "See Author Information."
-  },
-  "front-matter": {
-    "label": ":front-matter:",
-    "insertText": "front-matter: ${1:any}",
-    "description": "If skip-front-matter is set via the API or CLI, any YAML-style frontmatter skimmed from the top of the document is stored in this attribute."
   },
   "keywords": {
     "label": ":keywords:",


### PR DESCRIPTION
Document how to keep static-site front matter (the `---`/`+++` metadata block at the top of a file) out of the preview by setting the `skip-front-matter` attribute through `asciidoc.preview.asciidoctorAttributes`, and why it must be set there rather than in the document header or an `.asciidoctorconfig` file (front matter is detected above the header, before either source is applied).

Also stop offering `:skip-front-matter:` and `:front-matter:` in the `:` document-attribute completion: both are set via the API/CLI (or populated by the processor) and have no effect when declared in the document, so suggesting them as something to set was misleading. They remain referenceable through `{ ... }` completion when present in the parsed document.