### PR TITLE
docs: explain refreshing the preview only on save (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * Mark "Paste image" as supported in VS Code for the Web in the support matrix: the document paste edit provider is registered unconditionally, so copying an image and pasting it with <kbd>Ctrl</kbd>+<kbd>V</kbd> in the editor works in the browser
 * Add a "File extensions and associations" page documenting the recognized extensions (`.adoc`, `.ad`, `.asciidoc`, `.asc`), how to use the extension with other extensions such as `.txt` via the `files.associations` setting, and why this is discouraged — a few features (workspace symbols, cross-file cross-reference completion, extension-less link resolution) look files up by the `.adoc` extension rather than by language, so they silently ignore non-`.adoc` files (#376)
 * Document how to keep static-site front matter (the `---`/`+++` metadata block at the top of a file) out of the preview by setting the `skip-front-matter` attribute through `asciidoc.preview.asciidoctorAttributes`, and why it must be set there rather than in the document header or `.asciidoctorconfig` (#104)
+* Document how to control when the preview updates: setting `asciidoc.preview.refreshInterval` to `0` disables live updates, after which the preview refreshes only on save (<kbd>Ctrl</kbd>+<kbd>S</kbd>, which re-reads `include::`d files from disk while keeping the scroll position) or on demand through the "Refresh Preview" command (a full reload that also picks up includes changed outside VS Code) — useful for heavy documents that contains complex MathJax equations (#229)
 
 ### Infrastructure
 

--- a/docs/modules/ROOT/pages/preview.adoc
+++ b/docs/modules/ROOT/pages/preview.adoc
@@ -13,6 +13,27 @@ The same commands as the Markdown extension are available:
 The preview updates automatically as you type.
 You can also force a refresh with the *AsciiDoc: Refresh Preview* command.
 
+== Control when the preview updates
+
+By default the preview re-renders as you type, throttled by the `asciidoc.preview.refreshInterval` setting (in milliseconds, `2000` by default).
+
+Set the interval to `0` to turn off live updates entirely:
+
+[source,json]
+----
+"asciidoc.preview.refreshInterval": 0
+----
+
+The preview then refreshes only when you ask for it, in one of two ways:
+
+Save (kbd:[Ctrl+S], Mac: kbd:[Cmd+S]):: Re-renders every open preview, keeping its scroll position.
+Saving an `include::`d file refreshes the preview too -- includes are read *from disk*, so the change must be saved (saving the parent while an include is still unsaved keeps showing the old include).
+
+*AsciiDoc: Refresh Preview* command:: Forces a refresh on demand without saving anything, and fully reloads the preview (styles, theme, webview shell), resetting the scroll position.
+Use it when an include was changed *outside* VS Code -- no save event fires there -- or when you want a clean rebuild.
+
+This is useful for documents with heavy content -- for example complex MathJax equations that would otherwise re-typeset and jump around on every keystroke.
+
 == AsciiDoc attributes
 
 Set AsciiDoc attributes used to render the preview through the `asciidoc.preview.asciidoctorAttributes` setting.


### PR DESCRIPTION
Document that setting asciidoc.preview.refreshInterval to 0 disables live updates, after which the preview refreshes only on save or through the "Refresh Preview" command, and clarify the difference between the two (save keeps scroll and re-reads includes from disk; the command fully reloads and picks up includes changed outside VS Code).

Resolves #229 
