### PR TITLE
docs: explain binding a keyboard shortcut to a snippet (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * Add a "File extensions and associations" page documenting the recognized extensions (`.adoc`, `.ad`, `.asciidoc`, `.asc`), how to use the extension with other extensions such as `.txt` via the `files.associations` setting, and why this is discouraged — a few features (workspace symbols, cross-file cross-reference completion, extension-less link resolution) look files up by the `.adoc` extension rather than by language, so they silently ignore non-`.adoc` files (#376)
 * Document how to keep static-site front matter (the `---`/`+++` metadata block at the top of a file) out of the preview by setting the `skip-front-matter` attribute through `asciidoc.preview.asciidoctorAttributes`, and why it must be set there rather than in the document header or `.asciidoctorconfig` (#104)
 * Document how to control when the preview updates: setting `asciidoc.preview.refreshInterval` to `0` disables live updates, after which the preview refreshes only on save (<kbd>Ctrl</kbd>+<kbd>S</kbd>, which re-reads `include::`d files from disk while keeping the scroll position) or on demand through the "Refresh Preview" command (a full reload that also picks up includes changed outside VS Code) — useful for heavy documents that contains complex MathJax equations (#229)
+* Document how to bind a keyboard shortcut to a specific snippet through VS Code's built-in `editor.action.insertSnippet` command, either by referencing a snippet by name or by giving the snippet body inline (#778)
 
 ### Infrastructure
 

--- a/docs/modules/ROOT/pages/snippets.adoc
+++ b/docs/modules/ROOT/pages/snippets.adoc
@@ -4,3 +4,37 @@
 The extension ships with code snippets for common AsciiDoc constructs, including (but not limited to) include statements, images, links, the document header, headings, lists, and blocks.
 
 To browse the full list, open the command palette and select *Insert Snippet*.
+
+== Bind a keyboard shortcut to a snippet
+
+VS Code does not let you assign a key directly in the snippet definition, but you can bind a shortcut to a *specific* snippet through the built-in `editor.action.insertSnippet` command.
+
+Open the command palette, run *Preferences: Open Keyboard Shortcuts (JSON)*, and add an entry.
+
+Reference an existing snippet by its name:
+
+[source,json]
+----
+{
+  "key": "ctrl+alt+i",
+  "command": "editor.action.insertSnippet",
+  "when": "editorLangId == asciidoc",
+  "args": { "name": "Insert image block" }
+}
+----
+
+The `name` matches the snippet title shown in the *Insert Snippet* list (for example `Insert link`, `Insert include statement`, `Insert table`).
+
+Alternatively, define the snippet body inline, without declaring a snippet first:
+
+[source,json]
+----
+{
+  "key": "ctrl+alt+l",
+  "command": "editor.action.insertSnippet",
+  "when": "editorLangId == asciidoc",
+  "args": { "snippet": "link:${1:url}[${2:text}]" }
+}
+----
+
+The `when` clause restricts the shortcut to AsciiDoc files so it does not clash with other languages.


### PR DESCRIPTION
VS Code can bind a key to a specific snippet through the built-in editor.action.insertSnippet command, either by referencing a snippet by name or by giving the snippet body inline. Document both forms.

Resolves #778 
