### PR TITLE
test(preview): lock down link role rendered as class (#645)

### DIFF
--- a/src/test/asciidoctorWebViewConverter.test.ts
+++ b/src/test/asciidoctorWebViewConverter.test.ts
@@ -231,6 +231,18 @@ I want to link to xref:docB.adoc#other_anchor[]`,
 </div>`,
     },
     {
+      // #645: the link role must render as the element's class. Regression guard
+      // for the `node.role` (always undefined in JS) → `node.getRole()` fix; the
+      // old code emitted `class="undefined"`.
+      title: 'Should render a macro link role as a class (#645)',
+      filePath: ['asciidoctorWebViewConverterTest.adoc'],
+      input: 'link:foo.adoc[role=bar]',
+      antoraDocumentContext: undefined,
+      expected: `<div class="paragraph">
+<p><a href="foo.adoc" class="bare bar" data-href="foo.adoc">foo.adoc</a></p>
+</div>`,
+    },
+    {
       title:
         'Should resolve "xref:" macro from included document referencing the source document',
       filePath: ['docA.adoc'],


### PR DESCRIPTION
Guard against a regression of the `node.role` (always undefined in JS) → `node.getRole()` fix that made a link role render as `class="undefined"` instead of the actual role.
