### PR TITLE
chore: set Guillaume Grossetie as author/maintainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "%description%",
   "version": "3.4.6-dev",
   "publisher": "asciidoctor",
-  "author": "João Pinto <lamego.pinto@gmail.com>",
+  "author": "Guillaume Grossetie <ggrossetie@yuzutech.fr>",
+  "contributors": [
+    "João Pinto <lamego.pinto@gmail.com>"
+  ],
   "license": "MIT",
   "readme": "README.md",
   "repository": {


### PR DESCRIPTION
Since I'm now the maintainer of the extension; record me has the package author. João Pinto, the original creator, is kept in the `contributors` field.
