### PR TITLE
refactor(preview): extract custom stylesheet path resolution into a pure module (#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 ### Infrastructure
 
 * Extract the pure completion logic (Antora resource id forms, Antora resource macro matching, xref/`<<` anchor id extraction, and the xref/`<<` query parsing and label building) into `vscode`-free modules and cover it with fast Node `test:unit` unit tests instead of the extension-host suite (#434)
+* Extract the custom preview stylesheet path resolution out of the WebView converter's `fixHref` into a pure, `vscode`-free `resolveStyleUri` module and cover it with fast Node `test:unit` unit tests, locking in the behaviour of a custom `asciidoc.preview.style` in the VS Code Web editor (#651): an `http:`/`https:`/`file:` URL is passed through verbatim (rather than being resolved against the project path), and a relative path resolves under the workspace folder — working on the `vscode-vfs://` filesystem used by github.dev/vscode.dev. The scheme detection is now case-insensitive, matching the webview resource-root whitelist
 * Migrate from webpack to esbuild
 * Switch Node.js extension output to `.mjs` and remove `"type": "module"` from `package.json` to prevent VS Code web worker host from misidentifying the CJS browser bundle as ESM
 * Migrate to Asciidoctor.js 4.0.x (#999)

--- a/src/features/preview/asciidoctorWebViewConverter.ts
+++ b/src/features/preview/asciidoctorWebViewConverter.ts
@@ -15,6 +15,7 @@ import { AsciidocPreviewSecurityLevel } from '../security.js'
 import { buildCustomStyleSheetLinks } from './customStyles.js'
 import { renderMathJax } from './mathjax.js'
 import { AsciidocPreviewConfiguration } from './previewConfig.js'
+import { resolveStyleUri } from './resolveStyleHref.js'
 
 const BAD_PROTO_RE = /^(vbscript|javascript|data):/i
 const GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/i
@@ -990,35 +991,19 @@ ${node.hasAttribute('manpurpose') ? this.generateManNameSection(node) : ''}`
     if (!href) {
       return href
     }
-
-    if (
-      href.startsWith('http:') ||
-      href.startsWith('https:') ||
-      href.startsWith('file:')
-    ) {
-      return href
+    // The URL-vs-file decision (including the VS Code Web `vscode-vfs://` case)
+    // lives in the pure, unit-tested `resolveStyleUri`; here we only turn its
+    // result into the final webview href.
+    const resolved = resolveStyleUri(
+      href,
+      getWorkspaceFolder(textDocumentUri)?.uri,
+      textDocumentUri,
+    )
+    if (resolved.kind === 'url') {
+      return resolved.href
     }
-
-    // Assume it must be a local file
-    if (href.startsWith('/') || /^[a-z]:\\/i.test(href)) {
-      return webviewResourceProvider
-        .asWebviewUri(vscode.Uri.file(href))
-        .toString()
-    }
-
-    // Use a workspace relative path if there is a workspace
-    const root = getWorkspaceFolder(textDocumentUri)
-    if (root) {
-      return webviewResourceProvider
-        .asWebviewUri(vscode.Uri.joinPath(root.uri, href))
-        .toString()
-    }
-
-    // Otherwise look relative to the AsciiDoc file
     return webviewResourceProvider
-      .asWebviewUri(
-        vscode.Uri.joinPath(uri.Utils.dirname(textDocumentUri), href),
-      )
+      .asWebviewUri(vscode.Uri.from(resolved.uri))
       .toString()
   }
 }

--- a/src/features/preview/resolveStyleHref.ts
+++ b/src/features/preview/resolveStyleHref.ts
@@ -1,0 +1,42 @@
+// Pure (vscode-free) resolution of a custom stylesheet path/URL into the URI the
+// preview should load, *before* it is handed to `asWebviewUri`. Kept free of any
+// `vscode` import (uses only `vscode-uri`) so it can be unit-tested under
+// `node --test`, including the VS Code Web scenario where the workspace lives on
+// a `vscode-vfs://` filesystem rather than on disk. See `AsciidoctorWebView
+// Converter.fixHref`, which is now a thin adapter over this.
+
+import { URI, Utils } from 'vscode-uri'
+
+export type ResolvedStyle =
+  | { kind: 'url'; href: string }
+  | { kind: 'uri'; uri: URI }
+
+/**
+ * Resolve a configured stylesheet reference (from `asciidoc.preview.style`, the
+ * `stylesheet` document attribute, or `asciidoc.preview.additionalStyles`) to
+ * either a passthrough URL or a URI to be turned into a webview URI.
+ *
+ * - A `http:`/`https:`/`file:` reference is used verbatim (the preview CSP
+ *   allows `https:`), so a remote stylesheet is *not* mistaken for a file and
+ *   resolved against the project path (the original cause of #651).
+ * - An absolute local path becomes a `file://` URI. NOTE: this has no counterpart
+ *   in the VS Code Web editor (whose files live on `vscode-vfs://`), so an
+ *   absolute path is a known limitation there.
+ * - A relative path resolves against the workspace folder when there is one, else
+ *   against the document's own directory — mirroring Asciidoctor's lookup and
+ *   working on any filesystem scheme (including `vscode-vfs://`).
+ */
+export function resolveStyleUri(
+  href: string,
+  workspaceFolder: URI | undefined,
+  documentUri: URI,
+): ResolvedStyle {
+  if (/^(https?|file):/i.test(href)) {
+    return { kind: 'url', href }
+  }
+  if (href.startsWith('/') || /^[a-z]:\\/i.test(href)) {
+    return { kind: 'uri', uri: URI.file(href) }
+  }
+  const base = workspaceFolder ?? Utils.dirname(documentUri)
+  return { kind: 'uri', uri: Utils.joinPath(base, href) }
+}

--- a/src/test/unit/resolveStyleHref.test.ts
+++ b/src/test/unit/resolveStyleHref.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { URI } from 'vscode-uri'
+import {
+  type ResolvedStyle,
+  resolveStyleUri,
+} from '../../features/preview/resolveStyleHref.js'
+
+// The VS Code Web editor (e.g. github.dev) mounts the workspace on a
+// `vscode-vfs://` filesystem rather than on disk — the scenario of #651.
+const workspace = URI.parse('vscode-vfs://github/acme/website')
+const document = URI.parse('vscode-vfs://github/acme/website/docs/guide.adoc')
+
+function asUri(resolved: ResolvedStyle): URI {
+  assert.equal(resolved.kind, 'uri', `expected a URI, got ${resolved.kind}`)
+  return (resolved as { kind: 'uri'; uri: URI }).uri
+}
+
+describe('resolveStyleUri (#651 custom stylesheet in the Web editor)', () => {
+  test('an https URL is passed through verbatim (not resolved against the project path)', () => {
+    const resolved = resolveStyleUri(
+      'https://cdn.example.com/theme.css',
+      workspace,
+      document,
+    )
+    assert.deepEqual(resolved, {
+      kind: 'url',
+      href: 'https://cdn.example.com/theme.css',
+    })
+  })
+
+  test('a file: URL is passed through verbatim', () => {
+    const resolved = resolveStyleUri(
+      'file:///opt/styles/theme.css',
+      workspace,
+      document,
+    )
+    assert.deepEqual(resolved, {
+      kind: 'url',
+      href: 'file:///opt/styles/theme.css',
+    })
+  })
+
+  test('a relative path resolves under the workspace folder (works on vscode-vfs)', () => {
+    const resolved = resolveStyleUri('styles/site.css', workspace, document)
+    assert.equal(
+      asUri(resolved).toString(),
+      'vscode-vfs://github/acme/website/styles/site.css',
+    )
+  })
+
+  test('with no workspace, a relative path resolves next to the document', () => {
+    const resolved = resolveStyleUri('styles/site.css', undefined, document)
+    assert.equal(
+      asUri(resolved).toString(),
+      'vscode-vfs://github/acme/website/docs/styles/site.css',
+    )
+  })
+
+  test('an absolute path becomes a file:// URI — a known limitation in the Web editor', () => {
+    // Documents (and guards against silent regressions of) the one case that
+    // still cannot work in github.dev, whose files live on vscode-vfs://.
+    const resolved = resolveStyleUri(
+      '/opt/styles/theme.css',
+      workspace,
+      document,
+    )
+    assert.equal(asUri(resolved).scheme, 'file')
+  })
+})


### PR DESCRIPTION
Move the URL-vs-file decision out of the WebView converter's `fixHref` into a pure, `vscode`-free `resolveStyleUri` module, and cover it with fast Node `test:unit` tests. This locks in the behaviour of a custom `asciidoc.preview.style` in the VS Code Web editor: an `http:`/`https:`/`file:` URL is passed through verbatim (not resolved against the project path — the original cause of #651), and a relative path resolves under the workspace folder, working on the `vscode-vfs://` filesystem used by github.dev/vscode.dev. Scheme detection is now case-insensitive, matching the webview resource-root whitelist.

Resolves #651 