### PR TITLE
chore(package): shrink the packaged VSIX from ~29 MB to ~14 MB

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,13 +1,44 @@
+# Ignore everything by default, then re-include only what ships in the VSIX.
+#
+# NOTE on vsce semantics: patterns are split into an "ignore" and a "negate"
+# (`!`) list and the negate list ALWAYS wins, regardless of line order. A broad
+# `!dir/` therefore re-includes the whole subtree and a later `dir/sub/` ignore
+# has no effect. Keep the re-includes as narrow as possible instead.
+# vsce also only ever collects production dependencies from node_modules, so
+# devDependencies never reach here.
 **/*
+
 !images/icon.png
 !dist/
-!syntaxes/
 !snippets/
 !media/
-!node_modules/
 !package.json
 !package.nls*.json
 !en.json
-!*.md
+!/*.md
 !asciidoc-language-configuration.json
 !LICENSE
+
+# Grammar: only the generated grammar is registered at runtime (see
+# contributes.grammars). The base/source grammars, the generator and the
+# snapshot-test grammars/fixtures under syntaxes/tests are dev-only.
+!syntaxes/asciidoc.tmLanguage.json
+
+# The desktop build keeps dependencies external (tasks/build-ext.mjs uses
+# `packages: 'external'`), so production dependencies ship in the VSIX. Re-include
+# only the file types needed at runtime; this drops the TypeScript sources,
+# sourcemaps, docs and linter/test config that dependencies bundle (~800 files).
+!node_modules/**/*.js
+!node_modules/**/*.cjs
+!node_modules/**/*.mjs
+!node_modules/**/*.json
+!node_modules/**/*.node
+!node_modules/**/*.wasm
+!node_modules/**/*.css
+!node_modules/**/*.html
+!node_modules/**/*.yml
+!node_modules/**/*.yaml
+!node_modules/**/*.txt
+!node_modules/**/*.png
+!node_modules/**/LICENSE*
+!node_modules/**/license*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Infrastructure
+
+* Shrink the packaged VSIX from ~29 MB / 3825 files to ~14 MB / 2503 files by excluding artifacts that are never loaded at runtime. Two changes: (1) `.vscodeignore` was reworked around how `vsce` actually collects files — it already ships only production dependencies, and it splits ignore/negate patterns into two lists where a `!` negate always wins regardless of order, so a broad `!node_modules/`/`!syntaxes/` re-included the whole subtree and later ignores had no effect. The re-includes are now narrow: `syntaxes/` ships only the registered `asciidoc.tmLanguage.json` (dropping the base/source grammars, the generator and the `syntaxes/tests` snapshot fixtures), and `node_modules/` re-includes only the file types needed at runtime (dropping the bundled TypeScript sources, source maps, docs and linter/test config). (2) `tasks/copy-mermaid.mjs` now filters the Mermaid bundle it copies into `media/`, keeping the ESM entry (`mermaid.esm.min.mjs`) and its lazily loaded `.mjs` chunks but dropping the TypeScript declarations, source maps (~51 MB alone) and the unused UMD builds (`mermaid.js`, `mermaid.min.js`) — taking `media/mermaid` from ~76 MB to ~15 MB
+
 ## 4.0.0 (pre-release) (2026-07-07) - @ggrossetie
 
 ### Features

--- a/tasks/copy-mermaid.mjs
+++ b/tasks/copy-mermaid.mjs
@@ -8,9 +8,23 @@ import { join } from 'node:path'
 const nodeModules = join(process.cwd(), 'node_modules')
 const media = join(process.cwd(), 'media')
 
+// The preview imports the ESM entry (`mermaid.esm.min.mjs`) and the `.mjs`
+// chunks it lazily loads; that is all that runs at runtime. TypeScript
+// declarations, source maps, the unused UMD builds (`mermaid.js`,
+// `mermaid.min.js`) and READMEs are dev artifacts — ~63 MB for Mermaid alone —
+// so keep them out of `media/` and the packaged VSIX.
+function keep(src) {
+  return (
+    !src.endsWith('.d.ts') &&
+    !src.endsWith('.map') &&
+    !src.endsWith('.md') &&
+    !/[/\\]mermaid(\.min)?\.js$/.test(src)
+  )
+}
+
 function copy(src, dest) {
   rmSync(dest, { recursive: true, force: true })
-  cpSync(src, dest, { recursive: true })
+  cpSync(src, dest, { recursive: true, filter: keep })
 }
 
 // Full Mermaid bundle (lazy-loads its own diagram chunks).
@@ -39,5 +53,6 @@ for (const { pkg, entry, chunks } of addons) {
   cpSync(join(srcDist, entry), join(destDist, entry))
   cpSync(join(srcDist, 'chunks', chunks), join(destDist, 'chunks', chunks), {
     recursive: true,
+    filter: keep,
   })
 }


### PR DESCRIPTION
Exclude artifacts that are never loaded at runtime, roughly halving the VSIX (3825 -> 2503 files, ~29 MB -> ~14 MB).

Rework `.vscodeignore` around how `vsce` collects files: it already ships only production dependencies, and it splits patterns into an ignore and a negate (`!`) list where the negate always wins regardless of order. A broad `!node_modules/`/`!syntaxes/` therefore re-included the whole subtree and later ignores had no effect. Narrow the re-includes so `syntaxes/` ships only the registered grammar and `node_modules/` ships only the runtime file types (dropping bundled `.ts` sources, source maps, docs and linter/test config, plus the `syntaxes/tests` snapshot fixtures).

Filter the Mermaid bundle in `tasks/copy-mermaid.mjs`: keep the ESM entry and its lazily loaded `.mjs` chunks, drop the TypeScript declarations, source maps (~51 MB alone) and unused UMD builds, taking `media/mermaid` from ~76 MB to ~15 MB.