### PR TITLE
feat: centralize VS Code variable resolution across settings (#1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* Resolve VS Code path variables consistently across the extension's settings (#1154). The `${...}` placeholders VS Code substitutes in `settings.json` are not exposed to extensions, so each setting reimplemented its own expansion — and only the bare `${workspaceFolder}` was handled, resolved differently depending on the context (the preview's `asciidoctorAttributes` used the *first* workspace folder while the PDF export used the document's own folder, which drift apart in a multi-root workspace). Expansion is now centralised in a single helper used by both the preview attributes and the PDF export (output directory and the `asciidoctor-pdf`/`wkhtmltopdf` command paths). It resolves the named `${workspaceFolder:Name}` form, the deprecated `${workspaceRoot}` alias, `${workspaceFolderBasename}`, `${userHome}`, `${pathSeparator}` (and its `${/}` shorthand) and `${env:NAME}` in addition to the bare `${workspaceFolder}` — which now consistently resolves against the *document's own* workspace folder, so multi-root workspaces behave predictably. An unresolvable placeholder is left untouched rather than collapsing to an empty string. `${userHome}` is only available on the desktop host (there is no home directory on the web extension host)
+
 ### Documentation
 
 * Clarify the `asciidoc.useWorkspaceRootAsBaseDirectory` setting description regarding how relative paths resolve when it is enabled (#700). Because Asciidoctor ties `docdir` to the base directory, setting the base directory to the workspace root makes `{docdir}` resolve to the workspace root as well — so it cannot be used to reach a file sitting next to the current document, and *every* include/image path in the top-level document (even a same-folder one) must be written relative to the workspace root. Includes inside an already-included file keep resolving relative to that file. This behaviour is identical in the preview and in the PDF export; the wording previously left it ambiguous. Clarified in the setting description (all locales) and in a dedicated "Base directory resolution" section on the "Settings" documentation page

--- a/src/commands/exportAsPDF.ts
+++ b/src/commands/exportAsPDF.ts
@@ -7,6 +7,11 @@ import { v4 as uuidv4 } from 'uuid'
 import * as vscode from 'vscode'
 import { Command } from '../core/commandManager.js'
 import { logger } from '../core/logger.js'
+import {
+  resolveVariables,
+  type VariableResolutionContext,
+} from '../core/variableSubstitution.js'
+import { buildVariableResolutionContext } from '../core/variableSubstitutionContext.js'
 import { getWorkspaceFolder } from '../core/workspace.js'
 import { AsciidocEngine } from '../features/asciidoctor/asciidocEngine.js'
 import { AsciidocTextDocument } from '../features/asciidoctor/asciidocTextDocument.js'
@@ -49,6 +54,17 @@ export class ExportAsPDF implements Command {
     const workspacePath =
       workspaceFolder?.uri.fsPath ?? path.dirname(doc.uri.fsPath)
 
+    // Context used to expand VS Code variables (`${workspaceFolder}`,
+    // `${env:…}`, …) in configured command and output paths. `${workspaceFolder}`
+    // falls back to the document's own directory when the document is not part
+    // of any workspace folder, so the export still works outside a workspace
+    // (#749).
+    const variableContext: VariableResolutionContext = {
+      ...buildVariableResolutionContext(doc.uri),
+      documentWorkspaceFolder: workspacePath,
+      defaultWorkspaceFolder: workspacePath,
+    }
+
     // Compute the default output path. By default the PDF is written next to the
     // document, but `asciidoc.pdf.outputDirectory` can redirect it elsewhere
     // while keeping the document's base name (#868).
@@ -57,6 +73,7 @@ export class ExportAsPDF implements Command {
       baseDirectory,
       workspacePath,
       asciidocTextDocument.fileName + '.pdf',
+      variableContext,
     )
 
     // When `asciidoc.pdf.askOutputLocation` is disabled, skip the save dialog
@@ -94,6 +111,7 @@ ${text}`
       const asciidoctorPdfCommand = await this.resolveAsciidoctorPdfCommand(
         asciidocPdfConfig,
         workspacePath,
+        variableContext,
       )
       if (asciidoctorPdfCommand === undefined) {
         return
@@ -154,10 +172,9 @@ ${text}`
       if (wkhtmltopdfCommandPath === '') {
         wkhtmltopdfCommandPath = `wkhtmltopdf${process.platform === 'win32' ? '.exe' : ''}`
       } else {
-        wkhtmltopdfCommandPath = wkhtmltopdfCommandPath.replace(
-          // biome-ignore lint/suspicious/noTemplateCurlyInString: magic-value used in the VS code settings
-          '${workspaceFolder}',
-          workspacePath,
+        wkhtmltopdfCommandPath = resolveVariables(
+          wkhtmltopdfCommandPath,
+          variableContext,
         )
       }
       try {
@@ -248,16 +265,16 @@ ${text}`
   private async resolveAsciidoctorPdfCommand(
     asciidocPdfConfig,
     workspacePath,
+    variableContext: VariableResolutionContext,
   ): Promise<{ cwd: string; command: string } | undefined> {
     let asciidoctorPdfCommandPath = asciidocPdfConfig.get(
       'asciidoctorPdfCommandPath',
       '',
     )
     if (asciidoctorPdfCommandPath !== '') {
-      asciidoctorPdfCommandPath = asciidoctorPdfCommandPath.replace(
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: magic-value used in the VS code settings
-        '${workspaceFolder}',
-        workspacePath,
+      asciidoctorPdfCommandPath = resolveVariables(
+        asciidoctorPdfCommandPath,
+        variableContext,
       )
       // use the command specified
       return {
@@ -571,14 +588,17 @@ export function _resolvePdfOutputPath(
   baseDirectory: string,
   workspacePath: string,
   pdfFileName: string,
+  variableContext?: VariableResolutionContext,
 ): string {
   if (!outputDirectory || outputDirectory.trim() === '') {
     return path.join(baseDirectory, pdfFileName)
   }
-  let directory = outputDirectory.replace(
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: magic-value used in the VS code settings
-    '${workspaceFolder}',
-    workspacePath,
+  let directory = resolveVariables(
+    outputDirectory,
+    variableContext ?? {
+      documentWorkspaceFolder: workspacePath,
+      defaultWorkspaceFolder: workspacePath,
+    },
   )
   if (!path.isAbsolute(directory)) {
     directory = path.resolve(workspacePath, directory)

--- a/src/core/variableSubstitution.ts
+++ b/src/core/variableSubstitution.ts
@@ -1,0 +1,121 @@
+/**
+ * Centralized resolution of VS Code "variable" placeholders (the `${...}`
+ * syntax used across `settings.json`).
+ *
+ * VS Code performs this substitution internally through its
+ * `ConfigurationResolverService`, which is **not** exposed to extensions
+ * (microsoft/vscode#2809, #46471). Every extension that wants to honor
+ * `${workspaceFolder}` and friends has to reimplement it — which is why this
+ * used to be duplicated (and resolved inconsistently) between the preview
+ * attributes and the PDF export command (#1154).
+ *
+ * This module is deliberately free of any `vscode` import: it takes a plain
+ * {@link VariableResolutionContext} of primitives so it can run in the browser
+ * build (no Node globals) and be unit-tested without the extension host. The
+ * callers, which do have access to `vscode`, are responsible for building the
+ * context.
+ */
+
+export interface VariableResolutionContext {
+  /**
+   * Absolute path of the workspace folder that owns the *current document*.
+   * `${workspaceFolder}` resolves against this first so that, in a multi-root
+   * workspace, a placeholder means "the folder of the file I'm working on"
+   * (#1154). Falls back to {@link defaultWorkspaceFolder} when the document is
+   * not inside any folder.
+   */
+  documentWorkspaceFolder?: string
+
+  /**
+   * Fallback for a bare `${workspaceFolder}` when the document has no owning
+   * folder — typically the first workspace folder.
+   */
+  defaultWorkspaceFolder?: string
+
+  /**
+   * All workspace folders keyed by name, used to resolve the named form
+   * `${workspaceFolder:Name}`.
+   */
+  workspaceFoldersByName?: Record<string, string | undefined>
+
+  /** Value for `${userHome}` (undefined on the web build). */
+  userHome?: string
+
+  /** Value for `${pathSeparator}` / `${/}`. */
+  pathSeparator?: string
+
+  /** Environment variables, used to resolve `${env:NAME}`. */
+  env?: Record<string, string | undefined>
+}
+
+// Matches `${name}` and `${name:argument}`. The name captures anything that is
+// not `:` or `}` so single-character variables such as `${/}` are handled too;
+// the argument (workspace folder name, env var name) captures up to the `}`.
+const VARIABLE_RX = /\$\{([^}:]+)(?::([^}]*))?\}/g
+
+/**
+ * Replace the VS Code variable placeholders in `value` using `context`.
+ *
+ * A placeholder that cannot be resolved (unknown variable, or a known variable
+ * whose value is not available in the given context — e.g. `${workspaceFolder}`
+ * with no open workspace) is left untouched. This is intentionally conservative:
+ * it preserves the previous behavior where an unresolvable placeholder remained
+ * as literal text rather than collapsing to an empty string.
+ */
+export function resolveVariables(
+  value: string,
+  context: VariableResolutionContext,
+): string {
+  return value.replace(
+    VARIABLE_RX,
+    (match, name: string, argument?: string) => {
+      const resolved = resolveVariable(name, argument, context)
+      return resolved ?? match
+    },
+  )
+}
+
+function resolveVariable(
+  name: string,
+  argument: string | undefined,
+  context: VariableResolutionContext,
+): string | undefined {
+  switch (name) {
+    case 'workspaceFolder':
+    // `${workspaceRoot}` is the deprecated alias VS Code still accepts.
+    case 'workspaceRoot':
+      if (argument !== undefined) {
+        return context.workspaceFoldersByName?.[argument]
+      }
+      return context.documentWorkspaceFolder ?? context.defaultWorkspaceFolder
+    case 'workspaceFolderBasename':
+    case 'workspaceRootFolderName': {
+      const folder =
+        argument !== undefined
+          ? context.workspaceFoldersByName?.[argument]
+          : (context.documentWorkspaceFolder ?? context.defaultWorkspaceFolder)
+      return folder === undefined ? undefined : basename(folder)
+    }
+    case 'userHome':
+      return context.userHome
+    case 'pathSeparator':
+    case '/':
+      return context.pathSeparator
+    case 'env':
+      // A missing environment variable resolves to an empty string, matching
+      // VS Code's own behavior for `${env:...}`.
+      return argument === undefined
+        ? undefined
+        : (context.env?.[argument] ?? '')
+    default:
+      return undefined
+  }
+}
+
+// Last path segment, tolerant of both `/` and `\` separators and of trailing
+// slashes, without pulling in Node's `path` (kept web-safe).
+function basename(folder: string): string {
+  const trimmed = folder.replace(/[\\/]+$/, '')
+  const lastSep = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  return lastSep === -1 ? trimmed : trimmed.slice(lastSep + 1)
+}

--- a/src/core/variableSubstitutionContext.ts
+++ b/src/core/variableSubstitutionContext.ts
@@ -1,0 +1,62 @@
+import os from 'node:os'
+import path from 'node:path'
+import * as vscode from 'vscode'
+import { isBrowserEnvironment } from './environment.js'
+import {
+  resolveVariables,
+  type VariableResolutionContext,
+} from './variableSubstitution.js'
+import { getWorkspaceFolder, getWorkspaceFolders } from './workspace.js'
+
+/**
+ * Build a {@link VariableResolutionContext} from the current VS Code state so
+ * that {@link resolveVariables} can expand `${workspaceFolder}` and friends the
+ * same way everywhere (#1154).
+ *
+ * Web-safety: this file is part of the browser bundle (the preview uses it), so
+ * it must not call anything unavailable on the web extension host. `path.sep`
+ * and `process.env` are safe (aliased / shimmed by the browser build), but
+ * `os.homedir()` is **not** implemented by `os-browserify` and would throw —
+ * hence it is only read on the desktop host.
+ */
+export function buildVariableResolutionContext(
+  documentUri?: vscode.Uri,
+): VariableResolutionContext {
+  // On the desktop host paths are compared/used as OS file-system paths; on the
+  // web host only the URI `path` is meaningful. This mirrors the existing
+  // handling in AsciidoctorAttributesConfig.
+  const isDesktop = vscode.env.uiKind === vscode.UIKind.Desktop
+  const pathOf = (uri: vscode.Uri) => (isDesktop ? uri.fsPath : uri.path)
+
+  const folders = getWorkspaceFolders() ?? []
+  const workspaceFoldersByName: Record<string, string> = {}
+  for (const folder of folders) {
+    workspaceFoldersByName[folder.name] = pathOf(folder.uri)
+  }
+
+  const documentFolder = documentUri
+    ? getWorkspaceFolder(documentUri)
+    : undefined
+
+  return {
+    documentWorkspaceFolder: documentFolder
+      ? pathOf(documentFolder.uri)
+      : undefined,
+    defaultWorkspaceFolder: folders.length ? pathOf(folders[0].uri) : undefined,
+    workspaceFoldersByName,
+    userHome: isBrowserEnvironment() ? undefined : os.homedir(),
+    pathSeparator: path.sep,
+    env: process.env,
+  }
+}
+
+/**
+ * Convenience wrapper that resolves the VS Code variables in `value` against the
+ * context of `documentUri`.
+ */
+export function resolveVariablesForDocument(
+  value: string,
+  documentUri?: vscode.Uri,
+): string {
+  return resolveVariables(value, buildVariableResolutionContext(documentUri))
+}

--- a/src/features/asciidoctor/asciidoctorAttributesConfig.ts
+++ b/src/features/asciidoctor/asciidoctorAttributesConfig.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import { findDefaultWorkspaceFolderUri } from '../../core/workspace.js'
+import { resolveVariablesForDocument } from '../../core/variableSubstitutionContext.js'
 
 export class AsciidoctorAttributesConfig {
   public static getPreviewAttributes(documentUri?: vscode.Uri): {} {
@@ -12,18 +12,17 @@ export class AsciidoctorAttributesConfig {
       documentUri ?? null,
     )
     const attributes = asciidocPreviewConfig.get('asciidoctorAttributes', {})
-    const workspacePath =
-      vscode.env.uiKind === vscode.UIKind.Desktop
-        ? findDefaultWorkspaceFolderUri()?.fsPath
-        : findDefaultWorkspaceFolderUri()?.path
+    // Expand VS Code variables (`${workspaceFolder}`, `${workspaceFolder:Name}`,
+    // `${env:…}`, …) consistently with the rest of the extension. `${workspaceFolder}`
+    // resolves against the document's own workspace folder so multi-root
+    // workspaces behave predictably (#1154).
     Object.keys(attributes).forEach((key) => {
       const attributeValue = attributes[key]
       if (typeof attributeValue === 'string') {
-        attributes[key] =
-          workspacePath === undefined
-            ? attributeValue
-            : // biome-ignore lint/suspicious/noTemplateCurlyInString: magic-value used in the VS code settings
-              attributeValue.replace('${workspaceFolder}', workspacePath)
+        attributes[key] = resolveVariablesForDocument(
+          attributeValue,
+          documentUri,
+        )
       }
     })
     return {

--- a/src/test/unit/variableSubstitution.test.ts
+++ b/src/test/unit/variableSubstitution.test.ts
@@ -1,0 +1,122 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: these tests assert on literal `${...}` VS Code placeholders
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  resolveVariables,
+  type VariableResolutionContext,
+} from '../../core/variableSubstitution.js'
+
+describe('resolveVariables', () => {
+  const context: VariableResolutionContext = {
+    documentWorkspaceFolder: '/home/jane/project-b',
+    defaultWorkspaceFolder: '/home/jane/project-a',
+    workspaceFoldersByName: {
+      'project-a': '/home/jane/project-a',
+      'project-b': '/home/jane/project-b',
+    },
+    userHome: '/home/jane',
+    pathSeparator: '/',
+    env: { HOME: '/home/jane', ASCIIDOC_OUT: 'build/out' },
+  }
+
+  test('resolves ${workspaceFolder} against the document folder', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolder}/images', context),
+      '/home/jane/project-b/images',
+    )
+  })
+
+  test('falls back to the default folder when the document has no folder', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolder}/images', {
+        ...context,
+        documentWorkspaceFolder: undefined,
+      }),
+      '/home/jane/project-a/images',
+    )
+  })
+
+  test('resolves the named ${workspaceFolder:Name} form', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolder:project-a}/out', context),
+      '/home/jane/project-a/out',
+    )
+  })
+
+  test('accepts the deprecated ${workspaceRoot} alias', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceRoot}/images', context),
+      '/home/jane/project-b/images',
+    )
+  })
+
+  test('resolves ${workspaceFolderBasename}', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolderBasename}', context),
+      'project-b',
+    )
+    assert.strictEqual(
+      resolveVariables('${workspaceFolderBasename}', {
+        documentWorkspaceFolder: 'C:\\Users\\jane\\my-docs\\',
+      }),
+      'my-docs',
+    )
+  })
+
+  test('resolves ${userHome}', () => {
+    assert.strictEqual(
+      resolveVariables('${userHome}/notes', context),
+      '/home/jane/notes',
+    )
+  })
+
+  test('resolves ${pathSeparator} and its ${/} shorthand', () => {
+    assert.strictEqual(
+      resolveVariables('a${pathSeparator}b${/}c', context),
+      'a/b/c',
+    )
+  })
+
+  test('resolves ${env:NAME}', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolder}/${env:ASCIIDOC_OUT}', context),
+      '/home/jane/project-b/build/out',
+    )
+  })
+
+  test('resolves a missing environment variable to an empty string', () => {
+    assert.strictEqual(
+      resolveVariables('[${env:DOES_NOT_EXIST}]', context),
+      '[]',
+    )
+  })
+
+  test('replaces several placeholders in one string', () => {
+    assert.strictEqual(
+      resolveVariables('${userHome}/${env:ASCIIDOC_OUT}', context),
+      '/home/jane/build/out',
+    )
+  })
+
+  test('leaves an unknown variable untouched', () => {
+    assert.strictEqual(resolveVariables('${file}/x', context), '${file}/x')
+  })
+
+  test('leaves ${workspaceFolder} untouched when no folder is available', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolder}/images', {}),
+      '${workspaceFolder}/images',
+    )
+  })
+
+  test('leaves an unknown named workspace folder untouched', () => {
+    assert.strictEqual(
+      resolveVariables('${workspaceFolder:nope}/x', context),
+      '${workspaceFolder:nope}/x',
+    )
+  })
+
+  test('returns the string unchanged when there is no placeholder', () => {
+    assert.strictEqual(resolveVariables('/plain/path', context), '/plain/path')
+  })
+})


### PR DESCRIPTION
VS Code does not expose its `${...}` variable substitution to extensions, so each setting reimplemented its own expansion — inconsistently. Only the bare `${workspaceFolder}` was handled, and it resolved differently per context: the preview attributes used the first workspace folder while the PDF export used the document's own folder, diverging in multi-root workspaces (#1154).

Add a single pure resolver (`variableSubstitution.ts`, no `vscode`/Node imports so it is web-safe and unit-testable) plus a web-safe adapter (`variableSubstitutionContext.ts`) that builds the context from VS Code state. `os.homedir()` is guarded behind `isBrowserEnvironment()` since os-browserify does not implement it.

Both the preview attributes and the PDF export (output directory and the asciidoctor-pdf/wkhtmltopdf command paths) now go through the helper. `${workspaceFolder}` resolves against the document's own workspace folder everywhere; `${workspaceFolder:Name}`, `${workspaceRoot}`, `${workspaceFolderBasename}`, `${userHome}`, `${pathSeparator}`/`${/}` and `${env:NAME}` are also supported. Unresolvable placeholders are left untouched rather than collapsing to an empty string.

Closes #1154 