### PR TITLE
chore: prepare for TypeScript strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -769,6 +769,7 @@
     "package": "npm run build && npm run build-web && vsce package",
     "deploy": "vsce publish -p",
     "lint": "npx @biomejs/biome check --write",
+    "typecheck": "tsc --noEmit",
     "format": "npx @biomejs/biome format --write",
     "pretest": "npm run build && npm run build-test",
     "test": "node ./src/test/runTest.mjs && npm run test:unit && npm run test:grammar",

--- a/src/features/asciidoctor/asciidoctorConfig.ts
+++ b/src/features/asciidoctor/asciidoctorConfig.ts
@@ -8,6 +8,11 @@ export interface AsciidoctorConfigProvider {
   activate(registry: Registry, documentUri: vscode.Uri): Promise<void>
 }
 
+/** State stored on the preprocessor extension instance between renders. */
+interface PrependConfigPreprocessorState {
+  asciidoctorConfigContent: string
+}
+
 /**
  * .asciidoctorconfig support.
  */
@@ -18,10 +23,10 @@ export class AsciidoctorConfig implements AsciidoctorConfigProvider {
     this.prependExtension = Extensions.newPreprocessor(
       'PrependConfigPreprocessorExtension',
       {
-        postConstruct: function () {
+        postConstruct: function (this: PrependConfigPreprocessorState) {
           this.asciidoctorConfigContent = ''
         },
-        process: function (doc, reader) {
+        process: function (this: PrependConfigPreprocessorState, doc, reader) {
           if (this.asciidoctorConfigContent.length > 0) {
             // otherwise an empty line at the beginning breaks level 0 detection
             reader.pushInclude(
@@ -47,12 +52,9 @@ export class AsciidoctorConfig implements AsciidoctorConfigProvider {
   ) {
     const asciidoctorConfigContent =
       await getAsciidoctorConfigContent(documentUri)
-    if (asciidoctorConfigContent !== undefined) {
-      ;(this.prependExtension as any).asciidoctorConfigContent =
-        asciidoctorConfigContent
-    } else {
-      ;(this.prependExtension as any).asciidoctorConfigContent = ''
-    }
+    const state = this
+      .prependExtension as unknown as PrependConfigPreprocessorState
+    state.asciidoctorConfigContent = asciidoctorConfigContent ?? ''
   }
 }
 
@@ -63,7 +65,7 @@ export async function getAsciidoctorConfigContent(
     | undefined = vscode.workspace.workspaceFolders?.map(
     (workspaceFolder) => workspaceFolder.uri,
   ),
-): Promise<String | undefined> {
+): Promise<string | undefined> {
   const directories = getConfigSearchDirectories(
     documentUri,
     workspaceFolderUris,

--- a/src/features/asciidoctor/asciidoctorIncludeItems.ts
+++ b/src/features/asciidoctor/asciidoctorIncludeItems.ts
@@ -9,6 +9,12 @@ interface IncludeEntry {
 
 export interface IncludeItems extends Array<IncludeEntry> {}
 
+/** State stored on the include processor extension instance between renders. */
+interface FindIncludeProcessorState {
+  includeItems: IncludeItems
+  includeIndex: number
+}
+
 export interface AsciidoctorIncludeItemsProvider {
   activate(registry: Registry)
 
@@ -26,7 +32,7 @@ export class AsciidoctorIncludeItems
     this.findIncludeProcessorExtension = Extensions.newIncludeProcessor(
       'FindIncludeProcessorExtension',
       {
-        postConstruct: function () {
+        postConstruct: function (this: FindIncludeProcessorState) {
           this.includeItems = []
           this.includeIndex = 0
         },
@@ -34,7 +40,13 @@ export class AsciidoctorIncludeItems
         handles: function (_target) {
           return true
         },
-        process: function (doc, reader, target, attrs) {
+        process: function (
+          this: FindIncludeProcessorState,
+          doc,
+          reader,
+          target,
+          attrs,
+        ) {
           // We don't meaningfully process the includes, we just want to identify
           // their line number and path if they belong in the base document.
           //
@@ -73,11 +85,15 @@ export class AsciidoctorIncludeItems
   }
 
   get() {
-    return (this.findIncludeProcessorExtension as any).includeItems
+    return (
+      this.findIncludeProcessorExtension as unknown as FindIncludeProcessorState
+    ).includeItems
   }
 
   reset() {
-    ;(this.findIncludeProcessorExtension as any).includeIndex = 0
-    ;(this.findIncludeProcessorExtension as any).includeItems = []
+    const state = this
+      .findIncludeProcessorExtension as unknown as FindIncludeProcessorState
+    state.includeIndex = 0
+    state.includeItems = []
   }
 }

--- a/src/test/unit/asciidoctorExtensionContributions.test.ts
+++ b/src/test/unit/asciidoctorExtensionContributions.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
-import { Extensions, type Registry } from '@asciidoctor/core'
+import {
+  type Block,
+  type BlockProcessor,
+  type BlockProcessorDslInterface,
+  Extensions,
+  type Reader,
+  type Registry,
+} from '@asciidoctor/core'
 import {
   ASCIIDOCTOR_EXTENSIONS_CONTRIBUTION_POINT,
   type AsciidoctorExtensionContext,
@@ -226,17 +233,21 @@ describe('registerContributedAsciidoctorExtensions', () => {
       contributes: contributingPackageJSON,
       exports: {
         registerAsciidoctorExtensions(r: Registry) {
-          r.block('shout', function () {
-            const self = this
-            self.onContext('paragraph')
-            self.process((parent, reader) =>
-              self.createBlock(
-                parent,
-                'paragraph',
-                reader.getLines().join('\n').toUpperCase(),
-              ),
-            )
-          })
+          r.block(
+            'shout',
+            function (this: BlockProcessor & BlockProcessorDslInterface) {
+              const self = this
+              self.onContext('paragraph')
+              self.process((parent, reader) =>
+                self.createBlock(
+                  parent as Block,
+                  'paragraph',
+                  (reader as Reader).getLines().join('\n').toUpperCase(),
+                  {},
+                ),
+              )
+            },
+          )
         },
       },
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,12 @@
     "target": "es2022",
     "outDir": "dist",
     "lib": ["dom", "es2022"],
+    "types": ["node"],
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
     "sourceMap": true,
     "rootDir": "."
   },


### PR DESCRIPTION
Enable every strict-family flag that already passes cleanly (noImplicitThis, strictFunctionTypes, strictBindCallApply, alwaysStrict, useUnknownInCatchVariables), declare the Node types explicitly via "types" (the browser profile keeps excluding them), and add a "typecheck" script so these flags are enforced outside build-test.

The noImplicitThis fixes type the `this` parameter of the Asciidoctor extension callbacks that stash state on the processor instance, using dedicated state interfaces instead of `as any` casts.