### PR TITLE
Bundle Mermaid in exported HTML

### DIFF
--- a/src/commands/saveHTML.ts
+++ b/src/commands/saveHTML.ts
@@ -4,11 +4,11 @@ import * as path from 'node:path'
 import * as vscode from 'vscode'
 import { Command } from '../core/commandManager.js'
 import { AsciidocEngine } from '../features/asciidoctor/asciidocEngine.js'
-import { AsciidocPreviewManager } from '../features/preview/previewManager.js'
 import {
   hasMermaidBlocks,
   injectMermaidExportScript,
 } from '../features/preview/mermaidExport.js'
+import { AsciidocPreviewManager } from '../features/preview/previewManager.js'
 import {
   resolveAsciidocDocument,
   WebviewContext,

--- a/src/commands/saveHTML.ts
+++ b/src/commands/saveHTML.ts
@@ -6,6 +6,10 @@ import { Command } from '../core/commandManager.js'
 import { AsciidocEngine } from '../features/asciidoctor/asciidocEngine.js'
 import { AsciidocPreviewManager } from '../features/preview/previewManager.js'
 import {
+  hasMermaidBlocks,
+  injectMermaidExportScript,
+} from '../features/preview/mermaidExport.js'
+import {
   resolveAsciidocDocument,
   WebviewContext,
 } from './resolveAsciidocDocument.js'
@@ -16,6 +20,7 @@ export class SaveHTML implements Command {
   constructor(
     private readonly engine: AsciidocEngine,
     private readonly previewManager: AsciidocPreviewManager,
+    private readonly extensionUri: vscode.Uri,
   ) {
     this.engine = engine
   }
@@ -38,7 +43,11 @@ export class SaveHTML implements Command {
       htmlPath = path.join(docPath.dir, docPath.name + '.html')
     }
 
-    const { output: html } = await this.engine.export(textDocument, 'html5')
+    const { output: exportedHtml } = await this.engine.export(
+      textDocument,
+      'html5',
+    )
+    const html = await this.withBundledMermaid(exportedHtml)
 
     fs.writeFile(htmlPath, html, function (err) {
       if (err) {
@@ -71,5 +80,24 @@ export class SaveHTML implements Command {
           }
         })
     })
+  }
+
+  private async withBundledMermaid(html: string): Promise<string> {
+    if (!hasMermaidBlocks(html)) {
+      return html
+    }
+    const mermaidBundle = await vscode.workspace.fs.readFile(
+      vscode.Uri.joinPath(
+        this.extensionUri,
+        'media',
+        'mermaid',
+        'export',
+        'mermaid-export.js',
+      ),
+    )
+    return injectMermaidExportScript(
+      html,
+      new TextDecoder().decode(mermaidBundle),
+    )
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,7 +231,9 @@ export async function activate(context: vscode.ExtensionContext) {
   commandManager.register(new commands.ToggleBoldCommand())
   commandManager.register(new commands.ToggleItalicCommand())
   commandManager.register(new commands.ToggleMonospaceCommand())
-  commandManager.register(new commands.SaveHTML(asciidocEngine, previewManager))
+  commandManager.register(
+    new commands.SaveHTML(asciidocEngine, previewManager, context.extensionUri),
+  )
   commandManager.register(
     new commands.SaveDocbook(asciidocEngine, previewManager),
   )

--- a/src/features/preview/mermaidExport.ts
+++ b/src/features/preview/mermaidExport.ts
@@ -1,0 +1,44 @@
+const MERMAID_BLOCK_RX = /<pre\b[^>]*\bclass=(["'])[^"']*\bmermaid\b/i
+
+function escapeScriptContent(script: string): string {
+  return script.replace(/<\/script/gi, '<\\/script')
+}
+
+export function hasMermaidBlocks(html: string): boolean {
+  return MERMAID_BLOCK_RX.test(html)
+}
+
+export function renderMermaidExportScript(script: string): string {
+  return `<script>
+${escapeScriptContent(script)}
+;(async () => {
+  const mermaid = globalThis.mermaid
+  if (!mermaid) {
+    return
+  }
+  const dark =
+    globalThis.matchMedia &&
+    globalThis.matchMedia('(prefers-color-scheme: dark)').matches
+  mermaid.initialize({ startOnLoad: false, theme: dark ? 'dark' : 'default' })
+  try {
+    await mermaid.run()
+  } catch (e) {
+    console.error('Mermaid rendering failed', e)
+  }
+})()
+</script>`
+}
+
+export function injectMermaidExportScript(
+  html: string,
+  script: string,
+): string {
+  if (!hasMermaidBlocks(html)) {
+    return html
+  }
+  const markup = renderMermaidExportScript(script)
+  if (html.includes('</body>')) {
+    return html.replace('</body>', () => `${markup}\n</body>`)
+  }
+  return `${html}\n${markup}`
+}

--- a/src/test/unit/mermaid.test.ts
+++ b/src/test/unit/mermaid.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 import { convert, Extensions } from '@asciidoctor/core'
+import { mermaidJSProcessor } from '../../features/preview/mermaid.js'
 import {
   hasMermaidBlocks,
   injectMermaidExportScript,
 } from '../../features/preview/mermaidExport.js'
-import { mermaidJSProcessor } from '../../features/preview/mermaid.js'
 
 async function convertWithMermaid(input: string): Promise<string> {
   const registry = Extensions.create()

--- a/src/test/unit/mermaid.test.ts
+++ b/src/test/unit/mermaid.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 import { convert, Extensions } from '@asciidoctor/core'
+import {
+  hasMermaidBlocks,
+  injectMermaidExportScript,
+} from '../../features/preview/mermaidExport.js'
 import { mermaidJSProcessor } from '../../features/preview/mermaid.js'
 
 async function convertWithMermaid(input: string): Promise<string> {
@@ -43,5 +47,35 @@ describe('mermaidJSProcessor', () => {
     const html = await convertWithMermaid('----\nplain listing\n----')
     assert.doesNotMatch(html, /class='mermaid'/)
     assert.match(html, /plain listing/)
+  })
+})
+
+describe('Mermaid export HTML support', () => {
+  test('detects Mermaid blocks rendered by the block processor', () => {
+    assert.equal(hasMermaidBlocks("<pre class='mermaid'>graph TD</pre>"), true)
+    assert.equal(
+      hasMermaidBlocks('<pre class="diagram mermaid">graph TD</pre>'),
+      true,
+    )
+    assert.equal(hasMermaidBlocks('<pre class="listing">graph TD</pre>'), false)
+  })
+
+  test('injects the bundled Mermaid script before the body closes', () => {
+    const html = "<html><body><pre class='mermaid'>graph TD</pre></body></html>"
+    const result = injectMermaidExportScript(
+      html,
+      "console.log('</script> safe'); const replacement = '$&'",
+    )
+    assert.match(result, /<script>/)
+    assert.ok(result.includes('<\\/script> safe'))
+    assert.ok(result.includes("const replacement = '$&'"))
+    assert.match(result, /mermaid\.initialize/)
+    assert.match(result, /await mermaid\.run/)
+    assert.match(result, /<\/script>\n<\/body>/)
+  })
+
+  test('leaves exported HTML without Mermaid untouched', () => {
+    const html = '<html><body><p>plain</p></body></html>'
+    assert.equal(injectMermaidExportScript(html, 'console.log(1)'), html)
   })
 })

--- a/tasks/copy-mermaid.mjs
+++ b/tasks/copy-mermaid.mjs
@@ -56,3 +56,13 @@ for (const { pkg, entry, chunks } of addons) {
     filter: keep,
   })
 }
+
+// The exported HTML is opened directly in a browser, outside the VS Code
+// WebView and without the media/ directory. Use Mermaid's standalone browser
+// build here: unlike the ESM entry, it has no dynamic imports, so inlining it
+// into the exported HTML will not try to fetch diagram chunks from file://.
+mkdirSync(join(media, 'mermaid', 'export'), { recursive: true })
+cpSync(
+  join(nodeModules, 'mermaid', 'dist', 'mermaid.min.js'),
+  join(media, 'mermaid', 'export', 'mermaid-export.js'),
+)


### PR DESCRIPTION
## Summary
- bundle Mermaid into exported HTML when the document contains `[mermaid]` blocks
- generate the export bundle from Mermaid's standalone browser build so exported files do not fetch ESM chunks over `file://`
- add focused tests for Mermaid export script injection, including `</script>` and `$&` safety

Fixes #1170

## Validation
- `npm run typecheck`
- `npm run build-test && node --test build/src/test/unit/mermaid.test.js`
- `npm run build`
